### PR TITLE
feat:  Sharpe ratio for Balancer, Uniswap and Sturdy Pools

### DIFF
--- a/packages/valory/customs/asset_lending/asset_lending.py
+++ b/packages/valory/customs/asset_lending/asset_lending.py
@@ -1,10 +1,15 @@
 import requests
+import pandas as pd
+import pyfolio as pf
+import numpy as np
+from datetime import datetime
 from typing import (
     Dict,
     Union,
     Any,
     List
 )
+
 
 REQUIRED_FIELDS = ("chains", "apr_threshold", "endpoint", "lending_asset", "current_pool")
 STURDY = 'Sturdy'
@@ -52,6 +57,90 @@ def fetch_aggregators(endpoint) -> List[Dict[str, Any]]:
         return {"error": f"REST API Errors: {result['errors']}"}
     
     return result
+
+def fetch_historical_data(limit: int = 4000):
+    """
+    Fetch historical data for WETH strategy.
+    
+    Args:
+        limit (int): The number of data points to fetch.
+    
+    Returns:
+        list: List of historical data entries.
+    """
+    # Calculate the timestamp for one year ago
+    current_time_ms = int(datetime.now().timestamp() * 1000)
+    one_year_ago_ms = current_time_ms - (365 * 24 * 60 * 60 * 1000)
+    
+    url = f"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/getV2AggregatorHistoricalData?last_time={one_year_ago_ms}&limit={limit}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise Exception("Failed to fetch historical data from STURDY API.")
+    return response.json()
+
+def calculate_daily_returns(base_apy, reward_apy=0):
+    """
+    Convert annualized APY to daily returns.
+
+    Args:
+        base_apy (float): Base APY as a decimal (e.g., 0.01 for 1%).
+        reward_apy (float): Rewards APY as a decimal.
+
+    Returns:
+        float: Daily return as a decimal.
+    """
+    annual_return = base_apy + reward_apy
+    daily_return = (1 + annual_return) ** (1 / 365) - 1
+    return daily_return
+
+def calculate_sharpe_ratio(daily_returns):
+    """
+    Calculate Sharpe ratio using Pyfolio.
+
+    Args:
+        daily_returns (pd.Series): Series of daily returns.
+
+    Returns:
+        float: Sharpe ratio.
+    """
+    return pf.timeseries.sharpe_ratio(daily_returns)
+
+def get_sharpe_ratio_for_address(address: str) -> float:
+    """
+    Calculate the Sharpe ratio for a given aggregator address.
+
+    Args:
+        address (str): The aggregator address.
+
+    Returns:
+        float: Sharpe ratio for the given address.
+    """
+    # Fetch historical data
+    historical_data = fetch_historical_data()
+    
+    records = []
+    for entry in historical_data:
+        timestamp = entry['timestamp']
+        if address in entry['doc']:
+            data = entry['doc'][address]
+            base_apy = data.get('baseAPY', 0)
+            rewards_apy = data.get('rewardsAPY', 0)
+            records.append({
+                'timestamp': timestamp,
+                'base_apy': base_apy,
+                'rewards_apy': rewards_apy
+            })
+    
+    # Convert records to DataFrame
+    df = pd.DataFrame(records)
+    # Calculate daily returns
+    df['daily_return'] = df.apply(
+        lambda row: calculate_daily_returns(row['base_apy'], row['rewards_apy']), axis=1
+    )
+    
+    # Calculate Sharpe ratio
+    sharpe_ratio = calculate_sharpe_ratio(df['daily_return'])
+    return sharpe_ratio
 
 def get_best_opportunity(chains, apr_threshold, endpoint, lending_asset, current_pool) -> Dict[str, Any]:
     data = fetch_aggregators(endpoint)

--- a/packages/valory/customs/asset_lending/component.yaml
+++ b/packages/valory/customs/asset_lending/component.yaml
@@ -15,3 +15,5 @@ callable: run
 dependencies:
   requests:
     version: <2.31.2,>=2.28.1
+  pyfolio:
+    version: ==0.9.2

--- a/packages/valory/customs/balancer_pools_search/component.yaml
+++ b/packages/valory/customs/balancer_pools_search/component.yaml
@@ -15,3 +15,5 @@ callable: run
 dependencies:
   requests:
     version: <2.31.2,>=2.28.1
+  pyfolio:
+    version: ==0.9.2

--- a/packages/valory/customs/uniswap_pools_search/component.yaml
+++ b/packages/valory/customs/uniswap_pools_search/component.yaml
@@ -17,3 +17,5 @@ dependencies:
     version: ==3.5.0
   requests:
     version: <2.31.2,>=2.28.1
+  pyfolio:
+    version: ==0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [ "Environment :: Console", "Environment :: Web Environment", "Dev
 include = "packages"
 
 [tool.poetry.dependencies]
-python = "<4.0,>=3.10"
+python = "<3.12,>=3.10"
 open-autonomy = "==0.18.3"
 open-aea-test-autonomy = "==0.18.3"
 open-aea = "==1.60.0"
@@ -36,3 +36,4 @@ openapi-spec-validator = "<0.5.0,>=0.4.0"
 hypothesis = "==6.21.6"
 requests = "<2.31.2,>=2.28.1"
 pyinstaller = "==6.8.0"
+pyfolio = "==0.9.2"

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     Authlib==1.2.0
     certifi==2021.10.8
     grpcio==1.53.0
+    pyfolio==0.9.2
     hypothesis==6.21.6
     jsonschema<4.4.0,>=4.3.0
     open-autonomy==0.18.3


### PR DESCRIPTION
This pull request introduces several new features and improvements across multiple modules related to asset lending and pool analysis. The most significant changes include the addition of historical data fetching, calculation of daily returns, and the implementation of Sharpe ratio calculations for various financial assets and pools.

### New Features and Improvements:

#### Asset Lending Enhancements:
* Added imports for `pandas`, `pyfolio`, `numpy`, and `datetime` in `asset_lending.py` to support new financial calculations.
* Implemented functions `fetch_historical_data`, `calculate_daily_returns`, `calculate_sharpe_ratio`, and `get_sharpe_ratio_for_address` to fetch historical data, calculate daily returns, and compute the Sharpe ratio for a given aggregator address.

#### Balancer Pools Analysis:
* Added imports for `pandas` and `pyfolio` in `balancer_pools_search.py` to enable data manipulation and financial analysis.
* Introduced `get_pool_sharpe_ratio` function to calculate the Sharpe ratio for a Balancer pool based on historical data retrieved from the Balancer API.

#### Uniswap Pools Analysis:
* Added `get_uniswap_pool_sharpe_ratio` function to calculate the Sharpe ratio for a Uniswap pool by fetching and analyzing data from the Uniswap subgraph pools