### PR TITLE
Add gitleaksignore entry for main.6f085b19.js file

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -814,9 +814,10 @@ e7f765f01378b43d3986e03dda55952c32b530ae:packages/valory/skills/optimus_abci/mod
 bc1baeb9996e5384711256efbfdc8ee32a274cad:packages/valory/skills/liquidity_trader_abci/behaviours.py:generic-api-key:1662
 8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js.map:generic-api-key:2
 8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js.map:generic-api-key:2
+8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js:generic-api-key:2
+8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js:generic-api-key:2
+8ea81720d2af98bc726ad6177c8e485450c5f7g6:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js:generic-api-key:2
 0b078c4c40926ae29f8fe18f3461969722da2457:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.303ae61d.js.map:generic-api-key:2
 0b078c4c40926ae29f8fe18f3461969722da2457:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.303ae61d.js.map:generic-api-key:2
 8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js:generic-api-key:2
 8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js:generic-api-key:2
-8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js.map:generic-api-key:1
-8ea81720d2af98bc726ad6177c8e485450c5e7d5:packages/valory/skills/optimus_abci/modius-ui-build/static/js/main.6f085b19.js.map:generic-api-key:1


### PR DESCRIPTION
This PR adds an entry to the .gitleaksignore file for the main.6f085b19.js file to prevent false positives in the git leaks detection.