### PR TITLE
Fix: Release flow to avoid building linux/arm/v7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,8 +86,8 @@ jobs:
               cd $SERVICE || exit 1
               echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin || exit 1
               docker buildx create --name multiarch-builder --driver docker-container --bootstrap --use
-              autonomy build-image --builder multiarch-builder --platform linux/amd64,linux/arm64,linux/arm/v7 --pre-install-command "apt install gfortran pkg-config libopenblas-dev liblapack-dev python3-dev libssl-dev libxml2-dev libxslt-dev libjpeg-dev -y" --push || exit 1
-              autonomy build-image --builder multiarch-builder --platform linux/amd64,linux/arm64,linux/arm/v7 --pre-install-command "apt install gfortran pkg-config libopenblas-dev liblapack-dev python3-dev libssl-dev libxml2-dev libxslt-dev libjpeg-dev -y" --push --version $VERSION || exit 1
+              autonomy build-image --builder multiarch-builder --platform linux/amd64,linux/arm64 --pre-install-command "apt install gfortran pkg-config libopenblas-dev liblapack-dev python3-dev libssl-dev libxml2-dev libxslt-dev libjpeg-dev -y" --push || exit 1
+              autonomy build-image --builder multiarch-builder --platform linux/amd64,linux/arm64 --pre-install-command "apt install gfortran pkg-config libopenblas-dev liblapack-dev python3-dev libssl-dev libxml2-dev libxslt-dev libjpeg-dev -y" --push --version $VERSION || exit 1
 
   build-agent-runner:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Building `linux/arm/v7` is taking longer than 6 hours limit of the CI