### PR TITLE
Fix/coingecko requests

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,10 +26,10 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeiahnbdig3cex2lb2gz5mjoakkbyxurpu73akouhua4yg2pespzozm",
         "contract/valory/balancer_queries/0.1.0": "bafybeifvnzj6glrktvk7ffjeawha2e76at7sxeyznokcb4zize2t6xcffu",
         "connection/valory/mirror_db/0.1.0": "bafybeig46y7nbyo7uldl5xlkbbgv65kpvhqf4abmca7auw24ja6lnvcwdy",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeih2q22e6h5gz7pbxlrkm2gcu3ia25mhfpwlp4miz5nr7oomenxtxu",
-        "skill/valory/optimus_abci/0.1.0": "bafybeif3ipa4yhfnbc7dui6j4ohm7ydf35aivs4aggmx4jpzvrwslrxrpm",
-        "agent/valory/optimus/0.1.0": "bafybeif5p5x3hjtl5eldawpwa4gjqw7e4m6qc45hx43bfeoyz3rhxykkwm",
-        "service/valory/optimus/0.1.0": "bafybeigox2rdrwsg4qpoumvvfzabcam2rnyc6m5zsancaodxb6ezrfokiq"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeicevcnkul6qkcx67ndanjvqe4nkmmj4pfppxbfesjflipiusgbl2e",
+        "skill/valory/optimus_abci/0.1.0": "bafybeidoyuy3vbyijnstwlu77bi6zy55nsoxcx6v43vp7rppsqj5t3sucy",
+        "agent/valory/optimus/0.1.0": "bafybeicg62ta7wyqee6ld6gfekwkkcbcnpokinmxtnmg2csi5jh6ctdo4a",
+        "service/valory/optimus/0.1.0": "bafybeieshjzvl7d33z3p4z5466dpz6yjoy4wceid3dlu2jd7trbelj2sq4"
     },
     "third_party": {
         "protocol/dvilela/kv_store/0.1.0": "bafybeihimf5f37uupxmugvagmaxworgmz7cxuqpikkyzlgldtbq46jbvci",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -52,8 +52,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeieteucm3rudnnbesnu53wbv3ojnhrwqbvfrsqwvhg6ksgriqyl67i
 - valory/abstract_round_abci:0.1.0:bafybeifsuf7sh5vlugnqinbqe2f7vnssuqyxcrzqgotohhwqewyjeibneu
 - valory/funds_manager:0.1.0:bafybeibmp2fhlsfqvxm7u3sgpjyeirhdrvbp6zjspxjbyucfpdrnyq5qai
-- valory/liquidity_trader_abci:0.1.0:bafybeih2q22e6h5gz7pbxlrkm2gcu3ia25mhfpwlp4miz5nr7oomenxtxu
-- valory/optimus_abci:0.1.0:bafybeif3ipa4yhfnbc7dui6j4ohm7ydf35aivs4aggmx4jpzvrwslrxrpm
+- valory/liquidity_trader_abci:0.1.0:bafybeicevcnkul6qkcx67ndanjvqe4nkmmj4pfppxbfesjflipiusgbl2e
+- valory/optimus_abci:0.1.0:bafybeidoyuy3vbyijnstwlu77bi6zy55nsoxcx6v43vp7rppsqj5t3sucy
 - valory/registration_abci:0.1.0:bafybeie6rd7zlws4rxzkwka5mzhk56mn6clj3ocxbkbgeaiawv2c6b6jtm
 - valory/reset_pause_abci:0.1.0:bafybeian7gymp6x6rn55uaf4u3dgirbzr43xvnsj2ev27stkadikjqz4du
 - valory/termination_abci:0.1.0:bafybeiht4uj5j3qqf2hewtzah7vcabb7okkjgi65jb76ddfltvjpk6bzxi

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=1.0.0, <2.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeif5p5x3hjtl5eldawpwa4gjqw7e4m6qc45hx43bfeoyz3rhxykkwm
+agent: valory/optimus:0.1.0:bafybeicg62ta7wyqee6ld6gfekwkkcbcnpokinmxtnmg2csi5jh6ctdo4a
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -123,16 +123,6 @@ OLAS_ADDRESSES = {
 AIRDROP_REWARDS_KEY_PREFIX = "airdrop_rewards_"
 AIRDROP_TOTAL_KEY = "total_airdrop_rewards"
 
-# Reward tokens that should be excluded from investment consideration
-REWARD_TOKEN_ADDRESSES = {
-    "mode": {
-        "0xcfD1D50ce23C46D3Cf6407487B2F8934e96DC8f9": "OLAS",  # OLAS on Mode
-    },
-    "optimism": {
-        "0xFC2E6e6BCbd49ccf3A5f029c79984372DcBFE527": "OLAS",  # OLAS on Optimism
-    },
-}
-
 # Round timeout constants for health check
 # These timeouts define how long specific rounds can run before being considered unhealthy
 # Used to prevent false restarts when the agent is performing legitimate long-running operations
@@ -302,7 +292,7 @@ REWARD_TOKEN_ADDRESSES = {
     },
     "optimism": {
         "0xFC2E6e6BCbd49ccf3A5f029c79984372DcBFE527": "OLAS",  # OLAS on Optimism
-        "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db": "XVELO",  # VELO on Optimism
+        "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db": "VELO",  # VELO on Optimism
     },
 }
 

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeia7bn2ahqqwkf63ptje6rfnftuwrsp33sswgpcbh5osbesxxr6g4m
   behaviours/__init__.py: bafybeic6c77h7amnhdximi2tunqofaw675bglv4g4do7q4oof4mqa7xuuu
   behaviours/apr_population.py: bafybeig7n6d3iwv4g6d24ve6mdwqn4uwxdyufccttszi3ofxpxderqra7q
-  behaviours/base.py: bafybeid65xtirdok7dpn4z6fxdctyyzzourh472k5wraajfprk7vzf7i4e
+  behaviours/base.py: bafybeie4pbyhcyoryx76zwk77vsjru77mxr4kijgv5w74en2ifc3ahrptu
   behaviours/call_checkpoint.py: bafybeiefvotuqgw5f3opyageabqluz2dlrgthfygj32ovpm6xv5m7b5vqa
   behaviours/check_staking_kpi_met.py: bafybeib6igm2itai3blnrxhyy277yabxwluifabzm43fkmp4fdxiw5q2eu
   behaviours/decision_making.py: bafybeigbe5qemvwbzmfrysvvtxtpqcq464ilur2mhq53paulwwkcq7toum

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -119,7 +119,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeie6rd7zlws4rxzkwka5mzhk56mn6clj3ocxbkbgeaiawv2c6b6jtm
 - valory/reset_pause_abci:0.1.0:bafybeian7gymp6x6rn55uaf4u3dgirbzr43xvnsj2ev27stkadikjqz4du
 - valory/termination_abci:0.1.0:bafybeiht4uj5j3qqf2hewtzah7vcabb7okkjgi65jb76ddfltvjpk6bzxi
-- valory/liquidity_trader_abci:0.1.0:bafybeih2q22e6h5gz7pbxlrkm2gcu3ia25mhfpwlp4miz5nr7oomenxtxu
+- valory/liquidity_trader_abci:0.1.0:bafybeicevcnkul6qkcx67ndanjvqe4nkmmj4pfppxbfesjflipiusgbl2e
 - valory/transaction_settlement_abci:0.1.0:bafybeiem4qoc2pdpxoingjqp3qnrdjwho67pd6amy7o3xjr5mpdrepctve
 - valory/funds_manager:0.1.0:bafybeibmp2fhlsfqvxm7u3sgpjyeirhdrvbp6zjspxjbyucfpdrnyq5qai
 behaviours:


### PR DESCRIPTION
__Fix: Prevent expensive x402 requests for spam tokens__

Resolves issue where agent was making costly CoinGecko API calls for spam tokens

__Changes:__

- Added `trusted=true` to SafeApi calls to filter out spam tokens at source
- Created `_fetch_reward_balances()` to separately fetch legitimate reward tokens via direct contract calls
- Added `_get_last_known_price()` fallback mechanism to use cached prices when CoinGecko fails
- Enhanced `_fetch_token_price()` with automatic fallback to last known cached price
