### PR TITLE
fix: add env variable for safe_contract_addresses in service config

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,7 +26,7 @@
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigkxqivphr5xkvkkteadxgmzzfk5woyoewk5ccyrsqxelmrb6wdzm",
         "skill/valory/optimus_abci/0.1.0": "bafybeih4qd72a44bntkec4iuf4ujccbfu5s4ccsfc3yyw2tdim7szbubc4",
         "agent/valory/optimus/0.1.0": "bafybeic5w27tvflidsvw7tvcwvj73h74pgqmniz5qqhpzkg4sjv7cdsklu",
-        "service/valory/optimus/0.1.0": "bafybeihyoxa42ibfgowv636wqsjrna42ixx7mx5incwsi27x5ulpywhewe"
+        "service/valory/optimus/0.1.0": "bafybeiaj7ihfxln34vf6nbdieuqmcfidbi5pd6wusswr45alnheqynybyy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -213,7 +213,7 @@ models:
       fund_requirements: ${FUND_REQUIREMENTS:dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
       rpc_urls:
         optimism: ${OPTIMISM_LEDGER_RPC:str:https://mainnet.optimism.io}
-      safe_contract_addresses: ${dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
+      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/mirror_db:0.1.0
 type: connection


### PR DESCRIPTION
## Summary
- Fix `funds_manager` skill's `safe_contract_addresses` in `service.yaml` to read from the `SAFE_CONTRACT_ADDRESSES` env var

## Test plan
- [ ] Deploy with `SAFE_CONTRACT_ADDRESSES` set and verify `/funds-status` returns the actual safe address instead of `0x000...000`
- [ ] Confirm CLI no longer reports "unknown address" error