### PR TITLE
ci: add All checks passed aggregate gate job

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -255,3 +255,19 @@ jobs:
       - name: e2e tests
         run: |
           tox -e py${{ matrix.python-version }}-linux -- -m 'e2e'
+
+  all_checks_passed:
+    name: All checks passed
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - coverage
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

- Adds an `all_checks_passed` meta job to `main_workflow.yml` that depends on all mandatory CI jobs (`lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan`, `test`, `coverage`) and fails if any dependency failed or was cancelled.
- Enables a single aggregate status-check context for main-branch protection, so future mandatory-job changes are made in the workflow's `needs:` list rather than in branch protection settings.
- Once merged, the "All checks passed" context should be added as a required status check on `main` (strict: true).

## Test plan

- [ ] CI runs on this PR and `All checks passed` appears in the checks list
- [ ] `All checks passed` goes green when every dependency succeeds
- [ ] Verify it would go red on a dependency failure (confirmed by inspecting the `if: always()` + `contains(needs.*.result, 'failure')` gate)
- [ ] After merge, add `All checks passed` as a required status check on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
