### PR TITLE
chore: bump genai + funds_manager + kv_store hashes

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,10 +23,10 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeidmgeliuzkzru7vijsiohv74kajl62rz6unhhmvrtfd3rbmehpl7i",
         "contract/valory/balancer_queries/0.1.0": "bafybeifikh3czxp46byinhh44zsovqgnsbevshbizqiqvkvul2o2bsocbi",
         "connection/valory/mirror_db/0.1.0": "bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeieucks4ygvcebmvqi6coxnpbqpo5odx4hji6yjif5q4r4s34gpylq",
-        "skill/valory/optimus_abci/0.1.0": "bafybeifmsejrei3b3tsiw2crfqxpxwl26lxk4zgnynnx6zmuj7c6ltnv7q",
-        "agent/valory/optimus/0.1.0": "bafybeib63afnkykc5o4rkbau6aiyyiwd2d5dsgxha5e77wvkzbxfewoviu",
-        "service/valory/optimus/0.1.0": "bafybeiawldqbuxzmzmdkpb7rv7xcwmqwub5cjvt7erwqvi273zkohwrteu"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy",
+        "skill/valory/optimus_abci/0.1.0": "bafybeifoq3b3kaans7w5yboasl53ud7xdr6fynvzd2gm4g5c2c3pze2gqq",
+        "agent/valory/optimus/0.1.0": "bafybeigocwpdytmzi7ltovky636qa6zbkkhl3wvajub6aflrzph6ytayfe",
+        "service/valory/optimus/0.1.0": "bafybeiciruuebz5kblrz6wglaoqcrdi7u25enwyokxqcncbgrpjw22fu6y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -48,19 +48,19 @@
         "contract/valory/staking_token/0.1.0": "bafybeic6rlrsdgo5my3nxiy247njlsn2tupodhcehxqis6dpfyz325bdp4",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
-        "connection/valory/x402/0.1.0": "bafybeihtnlwawysnuvlrsflivrn76gacrcubo7feh656lwcz3leswiywum",
+        "connection/valory/x402/0.1.0": "bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi",
         "connection/valory/ledger/0.19.0": "bafybeia7ug4lrctgfwbq7dozqf5nvjqonot7uhtnlhdjidx5qipgy5743m",
         "connection/valory/http_server/0.22.0": "bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle",
         "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
         "connection/valory/ipfs/0.1.0": "bafybeift7qz5t4ranrpdcbbojwlmh5mxktr6tjrgivc7xsuqswxqa2wp5y",
-        "connection/valory/genai/0.1.0": "bafybeiaojqgrxeiwzmhqhbhz5evwjljm3chuwey4olt4snwwxwhufpeoum",
-        "connection/valory/kv_store/0.1.0": "bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq",
+        "connection/valory/genai/0.1.0": "bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4",
+        "connection/valory/kv_store/0.1.0": "bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq",
         "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54",
         "skill/valory/abstract_round_abci/0.1.0": "bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q",
         "skill/valory/registration_abci/0.1.0": "bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa",
         "skill/valory/termination_abci/0.1.0": "bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu",
-        "skill/valory/funds_manager/0.1.0": "bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i"
+        "skill/valory/funds_manager/0.1.0": "bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii"
     }
 }

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -14,10 +14,10 @@ connections:
 - valory/ipfs:0.1.0:bafybeift7qz5t4ranrpdcbbojwlmh5mxktr6tjrgivc7xsuqswxqa2wp5y
 - valory/ledger:0.19.0:bafybeia7ug4lrctgfwbq7dozqf5nvjqonot7uhtnlhdjidx5qipgy5743m
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
-- valory/genai:0.1.0:bafybeiaojqgrxeiwzmhqhbhz5evwjljm3chuwey4olt4snwwxwhufpeoum
-- valory/kv_store:0.1.0:bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq
+- valory/genai:0.1.0:bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4
+- valory/kv_store:0.1.0:bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq
 - valory/mirror_db:0.1.0:bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y
-- valory/x402:0.1.0:bafybeihtnlwawysnuvlrsflivrn76gacrcubo7feh656lwcz3leswiywum
+- valory/x402:0.1.0:bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeicutxdhfofyqt3l2y4udiqgfh22n3sn6fl2i5r7txd2kctvuig4e4
@@ -51,9 +51,9 @@ protocols:
 skills:
 - valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
-- valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
-- valory/liquidity_trader_abci:0.1.0:bafybeieucks4ygvcebmvqi6coxnpbqpo5odx4hji6yjif5q4r4s34gpylq
-- valory/optimus_abci:0.1.0:bafybeifmsejrei3b3tsiw2crfqxpxwl26lxk4zgnynnx6zmuj7c6ltnv7q
+- valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
+- valory/liquidity_trader_abci:0.1.0:bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy
+- valory/optimus_abci:0.1.0:bafybeifoq3b3kaans7w5yboasl53ud7xdr6fynvzd2gm4g5c2c3pze2gqq
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeib63afnkykc5o4rkbau6aiyyiwd2d5dsgxha5e77wvkzbxfewoviu
+agent: valory/optimus:0.1.0:bafybeigocwpdytmzi7ltovky636qa6zbkkhl3wvajub6aflrzph6ytayfe
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -96,8 +96,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/mirror_db:0.1.0:bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y
-- valory/kv_store:0.1.0:bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq
-- valory/x402:0.1.0:bafybeihtnlwawysnuvlrsflivrn76gacrcubo7feh656lwcz3leswiywum
+- valory/kv_store:0.1.0:bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq
+- valory/x402:0.1.0:bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
 - valory/balancer_weighted_pool:0.1.0:bafybeieqzno67yf4nqa2qnykovdtnxbswqo7pdafftmex5rv7xxpnykwky

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -114,8 +114,8 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
-- valory/genai:0.1.0:bafybeiaojqgrxeiwzmhqhbhz5evwjljm3chuwey4olt4snwwxwhufpeoum
-- valory/kv_store:0.1.0:bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq
+- valory/genai:0.1.0:bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4
+- valory/kv_store:0.1.0:bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq
 contracts: []
 protocols:
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
@@ -126,9 +126,9 @@ skills:
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/liquidity_trader_abci:0.1.0:bafybeieucks4ygvcebmvqi6coxnpbqpo5odx4hji6yjif5q4r4s34gpylq
+- valory/liquidity_trader_abci:0.1.0:bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
-- valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
+- valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,9 @@ service_specific_packages_exclude = [
 ]
 upstream_pins = [
     "valory-xyz/mech-interact@v0.30.0",
-    "valory-xyz/genai@v7.0.0",
-    "valory-xyz/kv-store@v0.5.0",
-    "valory-xyz/funds-manager@v3.0.0",
+    "valory-xyz/genai@v7.1.1",
+    "valory-xyz/kv-store@v0.5.1",
+    "valory-xyz/funds-manager@v3.0.1",
 ]
 gitleaks_extra_paths = [
     "packages/valory/skills/.*_abci/.*-ui-build/.*",

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ extra_deps =
     eth-account
     eth_account
     eth_abi
+    eth-abi
     eth_utils
+    eth-utils
     httpx
 
 [pytest]


### PR DESCRIPTION
## Summary
Bumps four merged upstream OA package hashes plus their cascaded dev-package rehashes.

| Package | New hash |
| --- | --- |
| `connection/valory/x402/0.1.0` | `bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi` (adds `PaymentRejectedAfterRetryError` subclass) |
| `connection/valory/genai/0.1.0` | `bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4` (valory-xyz/genai#32) |
| `connection/valory/kv_store/0.1.0` | `bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq` (valory-xyz/kv-store#13: ERROR perf on DB failure, key-filtered reads) |
| `skill/valory/funds_manager/0.1.0` | `bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii` (now declares `eth-abi` / `eth-utils` deps) |

`autonomy packages lock` cascaded the new third-party hashes into `liquidity_trader_abci`, `optimus_abci`, `optimus` agent, and `optimus` service. `autonomy push-all` published every updated component.

The repo did not list `protocol/valory/llm/1.0.0` or `connection/valory/openai/0.1.0`, so per the brief no new keys were added. `protocol/valory/srr/0.1.0` and `protocol/valory/kv_store/0.1.0` already matched the target hashes.

## Regressions found
None. Surface scan:
- **x402 / genai**: only consumers of `PaymentError` are inside the bumped packages themselves. The new `PaymentRejectedAfterRetryError` is a `PaymentError` subclass, so `genai/connection.py:334` `except PaymentError as e:` catches it via IS-A. No Optimus-side substring matches on the old message wording.
- **kv_store**: `liquidity_trader_abci.behaviours.base._read_kv` and `optimus_abci.handlers._read_kv` already (a) pass real key tuples and (b) treat any non-`READ_RESPONSE` performative (including the new `ERROR`) as a failure, falling back to `None` / `{}`. The new connection-side key filtering is invariant to the consumer because `_read_kv` already does `{key: response.data.get(key, None) for key in keys}`.
- **funds_manager**: public surface (`GET_FUNDS_STATUS_METHOD_NAME`, `FundRequirements`, `FundsManagerBehaviour.get_funds_status() -> FundRequirements`) is unchanged. `optimus_abci/handlers.py:472 funds_status` consumer call shape is unaffected.

## tox.ini change
Added hyphenated `eth-abi` and `eth-utils` to `[tomte-extensions] extra_deps`. The new `funds_manager/skill.yaml` declares those deps with hyphens, and `aea-helpers check-dependencies` does not normalise hyphen/underscore. The underscore forms already present in tox.ini stay for any package that declares them that way.

## Test plan
- [x] `autonomy packages sync --update-packages`
- [x] `autonomy packages lock --check`
- [x] `autonomy push-all`
- [x] `tomte tox -e check-hash` / `check-packages` / `check-dependencies`
- [x] `tomte tox -e check-abci-docstrings` / `check-abciapp-specs` / `check-handlers`
- [x] `tomte tox -p -e black-check -e isort-check -e mypy -e pylint -e darglint`
- [x] `tomte tox -p -e safety -e bandit`
- [x] `tomte check-doc-links`
- [x] `tomte tox -e py3.12-darwin` (4145 tests passed)
- [x] **Live agent boot** (`autonomy fetch --local`, agent built from bumped local source):
  - `GET /funds-status` → 200 in 2.4s with real Optimism balances (funds_manager multicall)
  - `POST /configure_strategies` with a chat prompt → 200 in 9.5s with structured LLM strategy response (full genai + x402 round-trip, `USE_X402=true`)
  - `kv_store`: 252 DB-related log lines, zero errors, SQLite file written to local data dir
- [ ] CI Py3.10 `flake8` — pre-existing Py3.12-only `E231` on `mirror_db/connection.py:403` does not reproduce on Py3.10; main run #25685347188 is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)