### PR TITLE
fix: on-chain fallback for whitelisted balances in get_positions

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,10 +23,10 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeidmgeliuzkzru7vijsiohv74kajl62rz6unhhmvrtfd3rbmehpl7i",
         "contract/valory/balancer_queries/0.1.0": "bafybeifikh3czxp46byinhh44zsovqgnsbevshbizqiqvkvul2o2bsocbi",
         "connection/valory/mirror_db/0.1.0": "bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy",
-        "skill/valory/optimus_abci/0.1.0": "bafybeiccoeisuupjsxbjo4h3ysparbunuhlhw5rcotc33errduldboleae",
-        "agent/valory/optimus/0.1.0": "bafybeibctu5o5k5jqciy25ys2kokid5cor6go2sydvtgh6drjqaima2g4y",
-        "service/valory/optimus/0.1.0": "bafybeid6iou6pzhvo3cpyeys6trzqiywm4rxq72kepqg6c3rnhjew77g5i"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiafciedryzkwo6tja4z4fxayw5fjve4myxd4kctc3uuxo5leh3ybm",
+        "agent/valory/optimus/0.1.0": "bafybeiaquhlmijb3qo2hn6v7fcesp7lo7reycxookka4fcxngri4ssdley",
+        "service/valory/optimus/0.1.0": "bafybeiaed3p56n5xh5ms4fkrjylkfqp7fynzwcnglucspijl7wr5gxdbra"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,10 +23,10 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeidmgeliuzkzru7vijsiohv74kajl62rz6unhhmvrtfd3rbmehpl7i",
         "contract/valory/balancer_queries/0.1.0": "bafybeifikh3czxp46byinhh44zsovqgnsbevshbizqiqvkvul2o2bsocbi",
         "connection/valory/mirror_db/0.1.0": "bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy",
-        "skill/valory/optimus_abci/0.1.0": "bafybeifoq3b3kaans7w5yboasl53ud7xdr6fynvzd2gm4g5c2c3pze2gqq",
-        "agent/valory/optimus/0.1.0": "bafybeigocwpdytmzi7ltovky636qa6zbkkhl3wvajub6aflrzph6ytayfe",
-        "service/valory/optimus/0.1.0": "bafybeiciruuebz5kblrz6wglaoqcrdi7u25enwyokxqcncbgrpjw22fu6y"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiccoeisuupjsxbjo4h3ysparbunuhlhw5rcotc33errduldboleae",
+        "agent/valory/optimus/0.1.0": "bafybeibctu5o5k5jqciy25ys2kokid5cor6go2sydvtgh6drjqaima2g4y",
+        "service/valory/optimus/0.1.0": "bafybeid6iou6pzhvo3cpyeys6trzqiywm4rxq72kepqg6c3rnhjew77g5i"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,10 +23,10 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeidmgeliuzkzru7vijsiohv74kajl62rz6unhhmvrtfd3rbmehpl7i",
         "contract/valory/balancer_queries/0.1.0": "bafybeifikh3czxp46byinhh44zsovqgnsbevshbizqiqvkvul2o2bsocbi",
         "connection/valory/mirror_db/0.1.0": "bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu",
-        "skill/valory/optimus_abci/0.1.0": "bafybeiafciedryzkwo6tja4z4fxayw5fjve4myxd4kctc3uuxo5leh3ybm",
-        "agent/valory/optimus/0.1.0": "bafybeiaquhlmijb3qo2hn6v7fcesp7lo7reycxookka4fcxngri4ssdley",
-        "service/valory/optimus/0.1.0": "bafybeiaed3p56n5xh5ms4fkrjylkfqp7fynzwcnglucspijl7wr5gxdbra"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiemdk35xt3qwrvly6il36qjfpe6lymhsqlatijqcn4bhpec7l32cy",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiaok4ftwi7vczrdr4cxycp6zyywzp75lsajpgu4ewye7pq3vwtcwm",
+        "agent/valory/optimus/0.1.0": "bafybeibofz3wlmmahwxmw2wb5a3f77f33igaieartc6map3yf7wqumn6wy",
+        "service/valory/optimus/0.1.0": "bafybeigcpif3zh337v72d7m3dxjk663gego4wpmbuz4s26363zydjjm33i"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -52,8 +52,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
-- valory/liquidity_trader_abci:0.1.0:bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy
-- valory/optimus_abci:0.1.0:bafybeiccoeisuupjsxbjo4h3ysparbunuhlhw5rcotc33errduldboleae
+- valory/liquidity_trader_abci:0.1.0:bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu
+- valory/optimus_abci:0.1.0:bafybeiafciedryzkwo6tja4z4fxayw5fjve4myxd4kctc3uuxo5leh3ybm
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -52,8 +52,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
-- valory/liquidity_trader_abci:0.1.0:bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy
-- valory/optimus_abci:0.1.0:bafybeifoq3b3kaans7w5yboasl53ud7xdr6fynvzd2gm4g5c2c3pze2gqq
+- valory/liquidity_trader_abci:0.1.0:bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy
+- valory/optimus_abci:0.1.0:bafybeiccoeisuupjsxbjo4h3ysparbunuhlhw5rcotc33errduldboleae
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -52,8 +52,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
-- valory/liquidity_trader_abci:0.1.0:bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu
-- valory/optimus_abci:0.1.0:bafybeiafciedryzkwo6tja4z4fxayw5fjve4myxd4kctc3uuxo5leh3ybm
+- valory/liquidity_trader_abci:0.1.0:bafybeiemdk35xt3qwrvly6il36qjfpe6lymhsqlatijqcn4bhpec7l32cy
+- valory/optimus_abci:0.1.0:bafybeiaok4ftwi7vczrdr4cxycp6zyywzp75lsajpgu4ewye7pq3vwtcwm
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeiaquhlmijb3qo2hn6v7fcesp7lo7reycxookka4fcxngri4ssdley
+agent: valory/optimus:0.1.0:bafybeibofz3wlmmahwxmw2wb5a3f77f33igaieartc6map3yf7wqumn6wy
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeigocwpdytmzi7ltovky636qa6zbkkhl3wvajub6aflrzph6ytayfe
+agent: valory/optimus:0.1.0:bafybeibctu5o5k5jqciy25ys2kokid5cor6go2sydvtgh6drjqaima2g4y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeibctu5o5k5jqciy25ys2kokid5cor6go2sydvtgh6drjqaima2g4y
+agent: valory/optimus:0.1.0:bafybeiaquhlmijb3qo2hn6v7fcesp7lo7reycxookka4fcxngri4ssdley
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -526,8 +526,10 @@ class LiquidityTraderBaseBehaviour(
 
         # On-chain backstop for whitelisted ERC20s and native ETH. Catches the
         # case where SafeApi is unavailable (e.g. monthly quota exceeded) or
-        # returns an incomplete trusted-token list. Reward tokens are handled
-        # by _fetch_reward_balances below, so no overlap here.
+        # returns an incomplete trusted-token list. Covers every entry in
+        # WHITELISTED_ASSETS[chain] including oUSDT, which used to be fetched
+        # separately. Reward tokens (OLAS, VELO) are disjoint from the
+        # whitelist and handled by _fetch_reward_balances below.
         yield from self._supplement_with_onchain_whitelisted_balances(
             "optimism", safe_address, balances
         )
@@ -536,13 +538,6 @@ class LiquidityTraderBaseBehaviour(
         reward_balances = yield from self._fetch_reward_balances("optimism")
         if reward_balances:
             balances.extend(reward_balances)
-
-        # Add separate OUSDT balance fetch for Optimism (not included in trusted API)
-        ousdt_balance = yield from self._fetch_ousdt_balance("optimism")
-        if ousdt_balance:
-            already_have = {b.get("address", "").lower() for b in balances}
-            if ousdt_balance.get("address", "").lower() not in already_have:
-                balances.append(ousdt_balance)
 
         self.context.logger.info(
             f"Retrieved {len(balances)} token balances from SafeApi"
@@ -3495,8 +3490,19 @@ class LiquidityTraderBaseBehaviour(
     ) -> Generator[None, None, None]:
         """Add on-chain balances for whitelisted assets not present in ``balances``.
 
-        Mutates ``balances`` in place. Skips any token whose address is already
-        in ``balances`` (case-insensitive). Also adds native ETH if missing.
+        Mutates ``balances`` in place. For each entry in ``WHITELISTED_ASSETS[chain]``
+        plus native ETH, appends an entry sourced from on-chain reads when:
+        - the address is not already in ``balances`` (case-insensitive match), and
+        - the on-chain balance is strictly positive.
+
+        Zero-balance tokens and tokens whose RPC read returns ``None`` are
+        skipped. The latter is logged as a warning so missing-data incidents
+        remain diagnosable.
+
+        :param chain: the chain to read on-chain balances from.
+        :param safe_address: the Safe contract address to read balances for.
+        :param balances: existing balances list to supplement in place.
+        :yield: None, for async-style generator progression.
         """
         already_have = {
             (b.get("address") or "").lower() for b in balances if b.get("address")
@@ -3523,7 +3529,13 @@ class LiquidityTraderBaseBehaviour(
             token_balance = yield from self._get_token_balance(
                 chain, safe_address, whitelisted_addr
             )
-            if not token_balance or token_balance <= 0:
+            if token_balance is None:
+                self.context.logger.warning(
+                    f"On-chain balance read returned None for {symbol or whitelisted_addr} "
+                    f"on {chain}; skipping. Positions data may be incomplete."
+                )
+                continue
+            if token_balance <= 0:
                 continue
             balances.append(
                 {
@@ -3591,50 +3603,6 @@ class LiquidityTraderBaseBehaviour(
         except Exception as e:
             self.context.logger.error(
                 f"Error getting last known price for token {token_address}: {str(e)}"
-            )
-            return None
-
-    def _fetch_ousdt_balance(
-        self, chain: str
-    ) -> Generator[None, None, Optional[Dict[str, Any]]]:
-        """Fetch OUSDT token balance separately using direct contract call."""
-        try:
-            safe_address = self.params.safe_contract_addresses.get(chain)
-            if not safe_address:
-                self.context.logger.error(f"No safe address found for chain {chain}")
-                return None
-
-            # OUSDT token address (same on both chains)
-            ousdt_token_address = (
-                "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"  # nosec B105
-            )
-
-            self.context.logger.info(
-                f"Fetching OUSDT balance separately for {chain} at address {ousdt_token_address}"
-            )
-
-            # Get OUSDT balance using direct contract call
-            ousdt_balance = yield from self._get_token_balance(
-                chain, safe_address, ousdt_token_address
-            )
-
-            if ousdt_balance and ousdt_balance > 0:
-                self.context.logger.info(
-                    f"Found OUSDT balance: {ousdt_balance} for {chain}"
-                )
-                return {
-                    "asset_symbol": "oUSDT",
-                    "asset_type": "erc_20",
-                    "address": to_checksum_address(ousdt_token_address),
-                    "balance": ousdt_balance,
-                }
-            else:
-                self.context.logger.info(f"No OUSDT balance found for {chain}")
-                return None
-
-        except Exception as e:
-            self.context.logger.error(
-                f"Error fetching OUSDT balance separately for {chain}: {str(e)}"
             )
             return None
 

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -524,6 +524,14 @@ class LiquidityTraderBaseBehaviour(
                         }
                     )
 
+        # On-chain backstop for whitelisted ERC20s and native ETH. Catches the
+        # case where SafeApi is unavailable (e.g. monthly quota exceeded) or
+        # returns an incomplete trusted-token list. Reward tokens are handled
+        # by _fetch_reward_balances below, so no overlap here.
+        yield from self._supplement_with_onchain_whitelisted_balances(
+            "optimism", safe_address, balances
+        )
+
         # Add separate reward token balance fetch for Optimism
         reward_balances = yield from self._fetch_reward_balances("optimism")
         if reward_balances:
@@ -532,7 +540,9 @@ class LiquidityTraderBaseBehaviour(
         # Add separate OUSDT balance fetch for Optimism (not included in trusted API)
         ousdt_balance = yield from self._fetch_ousdt_balance("optimism")
         if ousdt_balance:
-            balances.append(ousdt_balance)
+            already_have = {b.get("address", "").lower() for b in balances}
+            if ousdt_balance.get("address", "").lower() not in already_have:
+                balances.append(ousdt_balance)
 
         self.context.logger.info(
             f"Retrieved {len(balances)} token balances from SafeApi"
@@ -3476,6 +3486,54 @@ class LiquidityTraderBaseBehaviour(
                 f"Error fetching reward balances for {chain}: {str(e)}"
             )
             return reward_balances
+
+    def _supplement_with_onchain_whitelisted_balances(
+        self,
+        chain: str,
+        safe_address: str,
+        balances: List[Dict[str, Any]],
+    ) -> Generator[None, None, None]:
+        """Add on-chain balances for whitelisted assets not present in ``balances``.
+
+        Mutates ``balances`` in place. Skips any token whose address is already
+        in ``balances`` (case-insensitive). Also adds native ETH if missing.
+        """
+        already_have = {
+            (b.get("address") or "").lower() for b in balances if b.get("address")
+        }
+
+        zero_addr_lc = ZERO_ADDRESS.lower()
+        if zero_addr_lc not in already_have:
+            native_balance = yield from self._get_native_balance(chain, safe_address)
+            if native_balance and native_balance > 0:
+                balances.append(
+                    {
+                        "asset_symbol": "ETH",
+                        "asset_type": "native",
+                        "address": to_checksum_address(ZERO_ADDRESS),
+                        "balance": int(native_balance),
+                    }
+                )
+                already_have.add(zero_addr_lc)
+
+        for whitelisted_addr, symbol in WHITELISTED_ASSETS.get(chain, {}).items():
+            key = whitelisted_addr.lower()
+            if key in already_have:
+                continue
+            token_balance = yield from self._get_token_balance(
+                chain, safe_address, whitelisted_addr
+            )
+            if not token_balance or token_balance <= 0:
+                continue
+            balances.append(
+                {
+                    "asset_symbol": symbol or "UNKNOWN",
+                    "asset_type": "erc_20",
+                    "address": to_checksum_address(whitelisted_addr),
+                    "balance": int(token_balance),
+                }
+            )
+            already_have.add(key)
 
     def _get_last_known_price(
         self, token_address: str

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -3510,42 +3510,61 @@ class LiquidityTraderBaseBehaviour(
 
         zero_addr_lc = ZERO_ADDRESS.lower()
         if zero_addr_lc not in already_have:
-            native_balance = yield from self._get_native_balance(chain, safe_address)
-            if native_balance and native_balance > 0:
-                balances.append(
-                    {
-                        "asset_symbol": "ETH",
-                        "asset_type": "native",
-                        "address": to_checksum_address(ZERO_ADDRESS),
-                        "balance": int(native_balance),
-                    }
+            try:
+                native_balance = yield from self._get_native_balance(
+                    chain, safe_address
                 )
-                already_have.add(zero_addr_lc)
+                if native_balance is None:
+                    self.context.logger.warning(
+                        f"On-chain native balance read returned None on {chain}; "
+                        f"skipping. Positions data may be incomplete."
+                    )
+                elif native_balance > 0:
+                    balances.append(
+                        {
+                            "asset_symbol": "ETH",
+                            "asset_type": "native",
+                            "address": to_checksum_address(ZERO_ADDRESS),
+                            "balance": int(native_balance),
+                        }
+                    )
+                    already_have.add(zero_addr_lc)
+            except Exception as e:
+                self.context.logger.warning(
+                    f"Error reading native balance on {chain}: {str(e)}"
+                )
 
         for whitelisted_addr, symbol in WHITELISTED_ASSETS.get(chain, {}).items():
             key = whitelisted_addr.lower()
             if key in already_have:
                 continue
-            token_balance = yield from self._get_token_balance(
-                chain, safe_address, whitelisted_addr
-            )
-            if token_balance is None:
+            try:
+                token_balance = yield from self._get_token_balance(
+                    chain, safe_address, whitelisted_addr
+                )
+                if token_balance is None:
+                    self.context.logger.warning(
+                        f"On-chain balance read returned None for {symbol or whitelisted_addr} "
+                        f"on {chain}; skipping. Positions data may be incomplete."
+                    )
+                    continue
+                if token_balance <= 0:
+                    continue
+                balances.append(
+                    {
+                        "asset_symbol": symbol or "UNKNOWN",
+                        "asset_type": "erc_20",
+                        "address": to_checksum_address(whitelisted_addr),
+                        "balance": int(token_balance),
+                    }
+                )
+                already_have.add(key)
+            except Exception as e:
                 self.context.logger.warning(
-                    f"On-chain balance read returned None for {symbol or whitelisted_addr} "
-                    f"on {chain}; skipping. Positions data may be incomplete."
+                    f"Error reading on-chain balance for "
+                    f"{symbol or whitelisted_addr} on {chain}: {str(e)}"
                 )
                 continue
-            if token_balance <= 0:
-                continue
-            balances.append(
-                {
-                    "asset_symbol": symbol or "UNKNOWN",
-                    "asset_type": "erc_20",
-                    "address": to_checksum_address(whitelisted_addr),
-                    "balance": int(token_balance),
-                }
-            )
-            already_have.add(key)
 
     def _get_last_known_price(
         self, token_address: str

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
   behaviours/apr_population.py: bafybeiblgitwaq2k4uu3djcjnq3emy3iyf47gwf3ip6llovtynoxp4z3rm
-  behaviours/base.py: bafybeihkwf4uhzwp3s56dzx7zabnrjetsuhkbb5s7acmblasbrihq3n3ce
+  behaviours/base.py: bafybeie3itpezgqda7tr2cia75dybmlljgln7dkrqhe2d6ihljlic54t5i
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeieidx73vhcck7i3o2wkr435tarz5ikl4sogopgocg5quakgtf3csy
   behaviours/decision_making.py: bafybeigqyc73h4htlfeygvzcbcld6w2vrxlgdcna6dt3gexuqyy5n2zrai
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
   tests/behaviours/test_apr_population.py: bafybeicftuvjxhrvzyz54zqd5pvj2kakxta3prxfzqbaumrb6xuwlm5oz4
-  tests/behaviours/test_base.py: bafybeibojn2pa6ax4exdponxu6mnguqmdi4pyhpvfexft6jjrxvpi2q5fe
+  tests/behaviours/test_base.py: bafybeict2ufljiwoofh6obu5b6p25o4rly2yx62a7slfqes3fqlknoi7tu
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidv7ckk3qqyovnynl5v7nuxwzbols7jkhkrtiwa3uv7lxi4nykqtm
   tests/behaviours/test_decision_making.py: bafybeiej4ww7k6vllzscrwaod6hcic3f33a24sdvk2a3ex5hjuw2bx6qwq

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
   behaviours/apr_population.py: bafybeiblgitwaq2k4uu3djcjnq3emy3iyf47gwf3ip6llovtynoxp4z3rm
-  behaviours/base.py: bafybeie3itpezgqda7tr2cia75dybmlljgln7dkrqhe2d6ihljlic54t5i
+  behaviours/base.py: bafybeih35lv7ogohlzy6n54ggulprlkauxiuskentmcxrljiuj5slmhtre
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeieidx73vhcck7i3o2wkr435tarz5ikl4sogopgocg5quakgtf3csy
   behaviours/decision_making.py: bafybeigqyc73h4htlfeygvzcbcld6w2vrxlgdcna6dt3gexuqyy5n2zrai
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
   tests/behaviours/test_apr_population.py: bafybeicftuvjxhrvzyz54zqd5pvj2kakxta3prxfzqbaumrb6xuwlm5oz4
-  tests/behaviours/test_base.py: bafybeict2ufljiwoofh6obu5b6p25o4rly2yx62a7slfqes3fqlknoi7tu
+  tests/behaviours/test_base.py: bafybeih2vevbzvbxuujmqv74xyoe7lfwkr2egeelh3yl6pqol5kaelmy4u
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidv7ckk3qqyovnynl5v7nuxwzbols7jkhkrtiwa3uv7lxi4nykqtm
   tests/behaviours/test_decision_making.py: bafybeiej4ww7k6vllzscrwaod6hcic3f33a24sdvk2a3ex5hjuw2bx6qwq

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
   behaviours/apr_population.py: bafybeiblgitwaq2k4uu3djcjnq3emy3iyf47gwf3ip6llovtynoxp4z3rm
-  behaviours/base.py: bafybeih35lv7ogohlzy6n54ggulprlkauxiuskentmcxrljiuj5slmhtre
+  behaviours/base.py: bafybeigwhpws3ixkxvtw37klod4jh6h2poexk42t5expdnm2mcwcjpk7fq
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeieidx73vhcck7i3o2wkr435tarz5ikl4sogopgocg5quakgtf3csy
   behaviours/decision_making.py: bafybeigqyc73h4htlfeygvzcbcld6w2vrxlgdcna6dt3gexuqyy5n2zrai
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
   tests/behaviours/test_apr_population.py: bafybeicftuvjxhrvzyz54zqd5pvj2kakxta3prxfzqbaumrb6xuwlm5oz4
-  tests/behaviours/test_base.py: bafybeih2vevbzvbxuujmqv74xyoe7lfwkr2egeelh3yl6pqol5kaelmy4u
+  tests/behaviours/test_base.py: bafybeib2rsxyekshvg73omwlg635r5dhvivd7dffqsg2pqwlxdi6dly4oa
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidv7ckk3qqyovnynl5v7nuxwzbols7jkhkrtiwa3uv7lxi4nykqtm
   tests/behaviours/test_decision_making.py: bafybeiej4ww7k6vllzscrwaod6hcic3f33a24sdvk2a3ex5hjuw2bx6qwq

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -1015,6 +1015,7 @@ class TestGetOptimismBalances:
         b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 2
         assert result[0]["asset_symbol"] == "ETH"
@@ -1038,6 +1039,7 @@ class TestGetOptimismBalances:
         b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
@@ -1059,6 +1061,7 @@ class TestGetOptimismBalances:
         b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
@@ -1069,6 +1072,7 @@ class TestGetOptimismBalances:
         b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
@@ -1078,7 +1082,8 @@ class TestGetOptimismBalances:
         b._fetch_safe_balances_with_pagination = _make_gen((True, []))  # type: ignore[assignment,method-assign]
         b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([{"asset_symbol": "VELO", "balance": 100}])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen({"asset_symbol": "oUSDT", "balance": 50})  # type: ignore[assignment,method-assign]
+        b._fetch_ousdt_balance = _make_gen({"asset_symbol": "oUSDT", "balance": 50, "address": "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"})  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 2
 
@@ -1097,6 +1102,7 @@ class TestGetOptimismBalances:
         b._read_kv = _make_gen({"safe_balances_optimism": json.dumps(cached_data)})  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 2
         assert result[0]["asset_symbol"] == "ETH"
@@ -1109,6 +1115,7 @@ class TestGetOptimismBalances:
         b._read_kv = _make_gen({"safe_balances_optimism": None})  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
@@ -1127,6 +1134,7 @@ class TestGetOptimismBalances:
         b._write_kv = _failing_write  # type: ignore[method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 1
 
@@ -1143,8 +1151,92 @@ class TestGetOptimismBalances:
         b._read_kv = _failing_read  # type: ignore[method-assign]
         b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
         b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
+
+
+class TestSupplementWithOnchainWhitelistedBalances:
+    """Test the on-chain backstop for whitelisted balances."""
+
+    USDC = "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
+
+    def test_adds_native_eth_when_missing(self) -> None:
+        """If SafeApi did not return ETH, the on-chain native balance is added."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(123456)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        native = [b for b in balances if b["asset_symbol"] == "ETH"]
+        assert len(native) == 1
+        assert native[0]["balance"] == 123456
+        assert native[0]["asset_type"] == "native"
+
+    def test_skips_native_eth_when_already_present(self) -> None:
+        """If SafeApi already returned ETH, the backstop must not duplicate it."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(999)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        balances = [
+            {
+                "asset_symbol": "ETH",
+                "asset_type": "native",
+                "address": ZERO_ADDRESS,
+                "balance": 100,
+            }
+        ]
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        eths = [b for b in balances if b["asset_symbol"] == "ETH"]
+        assert len(eths) == 1
+        assert eths[0]["balance"] == 100  # preserves SafeApi value
+
+    def test_adds_whitelisted_erc20_when_missing(self) -> None:
+        """USDC absent from balances and non-zero on-chain is appended."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(5_000_000)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        symbols = {b["asset_symbol"] for b in balances}
+        assert "USDC" in symbols
+
+    def test_skips_whitelisted_erc20_when_already_present(self) -> None:
+        """Token already in balances (case-insensitive address match) is not re-added."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(9_999_999)  # type: ignore[assignment,method-assign]
+        # SafeApi-reported USDC at value 42, with a mixed-case address.
+        balances = [
+            {
+                "asset_symbol": "USDC",
+                "asset_type": "erc_20",
+                "address": self.USDC.upper().replace("0X", "0x"),
+                "balance": 42,
+            }
+        ]
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        usdc_entries = [b for b in balances if b["asset_symbol"] == "USDC"]
+        assert len(usdc_entries) == 1
+        assert usdc_entries[0]["balance"] == 42
+
+    def test_skips_zero_onchain_balance(self) -> None:
+        """A whitelisted token with zero on-chain balance is not appended."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        assert balances == []
+
+    def test_skips_when_get_token_balance_returns_none(self) -> None:
+        """RPC failure (returns None) does not add a stub entry."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        assert balances == []
 
 
 class TestGetModeBalances:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -41,6 +41,7 @@ from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
     PRICE_CACHE_KEY_PREFIX,
     REWARD_UPDATE_INTERVAL,
     REWARD_UPDATE_KEY_PREFIX,
+    WHITELISTED_ASSETS,
     ZERO_ADDRESS,
     execute_strategy,
 )
@@ -1232,18 +1233,40 @@ class TestSupplementWithOnchainWhitelistedBalances:
         assert eths[0]["balance"] == 100  # preserves SafeApi value
 
     def test_adds_whitelisted_erc20_when_missing(self) -> None:
-        """USDC absent from balances and non-zero on-chain is appended."""
+        """Every whitelisted ERC20 with a positive on-chain balance is appended."""
         b = _make_behaviour()
         b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
-        b._get_token_balance = _make_gen(5_000_000)  # type: ignore[assignment,method-assign]
+        # Per-address fake pins the symbol-to-address mapping: a mismatch in the
+        # loop (wrong key, short-circuit, swapped symbol) would surface as a
+        # missing/incorrect balance in the asserted dict.
+        expected = {
+            addr: i + 1 for i, addr in enumerate(WHITELISTED_ASSETS["optimism"])
+        }
+
+        def fake_token_balance(
+            chain: str, account: str, address: str
+        ) -> Generator[Any, Any, Any]:
+            """Per-address balance fake."""
+            yield
+            return expected[address]
+
+        b._get_token_balance = fake_token_balance  # type: ignore[method-assign]
         balances: list = []
         _exhaust(
             b._supplement_with_onchain_whitelisted_balances(
                 "optimism", "0xsafe", balances
             )
         )
-        symbols = {b["asset_symbol"] for b in balances}
-        assert "USDC" in symbols
+        # Pin: every whitelisted entry must be present with the exact balance
+        # produced by the per-address fake (catches loop short-circuit and
+        # symbol/address mapping swaps).
+        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
+        balance_by_address = {entry["address"].lower(): entry for entry in balances}
+        for address, symbol in WHITELISTED_ASSETS["optimism"].items():
+            entry = balance_by_address[address.lower()]
+            assert entry["asset_symbol"] == symbol
+            assert entry["asset_type"] == "erc_20"
+            assert entry["balance"] == expected[address]
 
     def test_skips_whitelisted_erc20_when_already_present(self) -> None:
         """Token already in balances (case-insensitive address match) is not re-added."""
@@ -1293,6 +1316,76 @@ class TestSupplementWithOnchainWhitelistedBalances:
             )
         )
         assert balances == []
+
+    def test_token_rpc_exception_continues_to_next_token(self) -> None:
+        """An RPC raise on one token must not abort the whole helper.
+
+        Guards against regression of the per-iteration try/except: if the
+        guard is removed, a single raise propagates out and kills the whole
+        positions round (the exact failure mode this helper exists to
+        mitigate).
+        """
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
+        addresses = list(WHITELISTED_ASSETS["optimism"].keys())
+        failing_address = addresses[0]
+
+        def flaky_token_balance(
+            chain: str, account: str, address: str
+        ) -> Generator[Any, Any, Any]:
+            """Raise for the first address; return 7 for the rest."""
+            if address == failing_address:
+                raise Exception("rpc timeout")
+                yield  # pragma: no cover - unreachable
+            yield
+            return 7
+
+        b._get_token_balance = flaky_token_balance  # type: ignore[method-assign]
+        balances: list = []
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
+        # Every address except the failing one is appended.
+        result_addresses = {entry["address"].lower() for entry in balances}
+        expected_addresses = {a.lower() for a in addresses if a != failing_address}
+        assert result_addresses == expected_addresses
+
+    def test_native_rpc_exception_does_not_block_erc20s(self) -> None:
+        """An RPC raise on the native fetch is logged and ERC20 reads still run."""
+        b = _make_behaviour()
+
+        def raising_native(*a: Any, **kw: Any) -> Generator[Any, Any, Any]:
+            """Raise on native fetch."""
+            raise Exception("native rpc failure")
+            yield  # pragma: no cover - unreachable
+
+        b._get_native_balance = raising_native  # type: ignore[method-assign]
+        b._get_token_balance = _make_gen(3)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
+        # No ETH entry, but every whitelisted ERC20 made it.
+        assert not any(entry["asset_symbol"] == "ETH" for entry in balances)
+        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
+
+    def test_native_none_does_not_block_erc20s(self) -> None:
+        """A native None read is logged and skipped; ERC20 backstop still runs."""
+        b = _make_behaviour()
+        b._get_native_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
+        b._get_token_balance = _make_gen(11)  # type: ignore[assignment,method-assign]
+        balances: list = []
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
+        assert not any(entry["asset_symbol"] == "ETH" for entry in balances)
+        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
 
 
 class TestGetModeBalances:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -985,6 +985,22 @@ class TestGetPositions:
         assert result == []
 
 
+def _make_optimism_b() -> Any:
+    """Behaviour with default no-op stubs for _get_optimism_balances_from_safe_api.
+
+    Stubs the reward fetch and the on-chain backstop to no-ops so tests can
+    isolate the SafeApi-parse and cache paths. Tests that need either side
+    to be live override the relevant stub.
+
+    :return: behaviour instance with the noop stubs installed.
+    """
+    b = _make_behaviour()
+    b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
+    b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
+    b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
+    return b
+
+
 class TestGetOptimismBalances:
     """Test _get_optimism_balances_from_safe_api."""
 
@@ -997,7 +1013,7 @@ class TestGetOptimismBalances:
 
     def test_with_balances(self) -> None:
         """Test with balances."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         token_addr = "0x" + "ab" * 20
         b._fetch_safe_balances_with_pagination = _make_gen(  # type: ignore[assignment,method-assign]
             (
@@ -1012,10 +1028,6 @@ class TestGetOptimismBalances:
                 ],
             )
         )
-        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 2
         assert result[0]["asset_symbol"] == "ETH"
@@ -1023,7 +1035,7 @@ class TestGetOptimismBalances:
 
     def test_skips_filtered_token(self) -> None:
         """Test skips filtered token."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen(  # type: ignore[assignment,method-assign]
             (
                 True,
@@ -1036,16 +1048,12 @@ class TestGetOptimismBalances:
                 ],
             )
         )
-        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
     def test_skips_token_without_info(self) -> None:
         """ERC-20 token with no token info is skipped."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen(  # type: ignore[assignment,method-assign]
             (
                 True,
@@ -1058,34 +1066,24 @@ class TestGetOptimismBalances:
                 ],
             )
         )
-        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
     def test_api_success_empty_no_cache_fallback(self) -> None:
         """API succeeds but Safe is empty - must NOT fall back to cache."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen((True, []))  # type: ignore[assignment,method-assign]
-        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
     def test_api_success_empty_with_rewards(self) -> None:
         """API succeeds, Safe empty, but reward tokens exist."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen((True, []))  # type: ignore[assignment,method-assign]
-        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
         b._fetch_reward_balances = _make_gen([{"asset_symbol": "VELO", "balance": 100}])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen({"asset_symbol": "oUSDT", "balance": 50, "address": "0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189"})  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
-        assert len(result) == 2
+        assert len(result) == 1
+        assert result[0]["asset_symbol"] == "VELO"
 
     def test_api_failure_falls_back_to_cache(self) -> None:
         """API fails - fall back to KV-cached balances."""
@@ -1097,12 +1095,9 @@ class TestGetOptimismBalances:
                 "balance": "5000000",
             },
         ]
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen((False, []))  # type: ignore[assignment,method-assign]
         b._read_kv = _make_gen({"safe_balances_optimism": json.dumps(cached_data)})  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 2
         assert result[0]["asset_symbol"] == "ETH"
@@ -1110,12 +1105,9 @@ class TestGetOptimismBalances:
 
     def test_api_failure_no_cache(self) -> None:
         """API fails and cache has no data - return empty."""
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen((False, []))  # type: ignore[assignment,method-assign]
         b._read_kv = _make_gen({"safe_balances_optimism": None})  # type: ignore[assignment,method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
 
@@ -1127,14 +1119,11 @@ class TestGetOptimismBalances:
                 yield  # noqa
             raise ConnectionError("KV write failed")
 
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen(  # type: ignore[assignment,method-assign]
             (True, [{"tokenAddress": None, "balance": "1000"}])
         )
         b._write_kv = _failing_write  # type: ignore[method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 1
 
@@ -1146,14 +1135,57 @@ class TestGetOptimismBalances:
                 yield  # noqa
             raise ConnectionError("KV read failed")
 
-        b = _make_behaviour()
+        b = _make_optimism_b()
         b._fetch_safe_balances_with_pagination = _make_gen((False, []))  # type: ignore[assignment,method-assign]
         b._read_kv = _failing_read  # type: ignore[method-assign]
-        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
-        b._fetch_ousdt_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
-        b._supplement_with_onchain_whitelisted_balances = _make_gen(None)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._get_optimism_balances_from_safe_api())
         assert len(result) == 0
+
+    def test_backstop_integrates_when_safeapi_partial(self) -> None:
+        """End-to-end backstop integration when SafeApi returns partial data.
+
+        SafeApi returns only ETH; the real backstop adds the whitelisted
+        ERC20s (including oUSDT) on top, without duplicating ETH.
+
+        This guards the ordering and dedup contract between
+        ``_get_optimism_balances_from_safe_api`` and the live
+        ``_supplement_with_onchain_whitelisted_balances``: if the backstop
+        is moved or its dedup loosened, this fails.
+        """
+        b = _make_behaviour()
+        b._write_kv = _make_gen(True)  # type: ignore[assignment,method-assign]
+        b._fetch_reward_balances = _make_gen([])  # type: ignore[assignment,method-assign]
+        # SafeApi returns ETH only (partial response).
+        b._fetch_safe_balances_with_pagination = _make_gen(  # type: ignore[assignment,method-assign]
+            (True, [{"tokenAddress": None, "balance": "1000000000000000"}])
+        )
+        # Backstop runs for real. Stub RPC reads so on-chain says:
+        # native ETH 999 (won't be added — ETH already came from SafeApi)
+        # oUSDT 5_000_000 (will be added by backstop)
+        # everything else: 0
+        OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        b._get_native_balance = _make_gen(999)  # type: ignore[assignment,method-assign]
+
+        def fake_token_balance(chain: Any, account: Any, address: Any) -> Any:
+            yield
+            return 5_000_000 if (address or "").lower() == OUSDT else 0
+
+        b._get_token_balance = fake_token_balance  # type: ignore[assignment,method-assign]
+
+        result = _exhaust(b._get_optimism_balances_from_safe_api())
+        symbols = [r["asset_symbol"] for r in result]
+        eth_entries = [r for r in result if r["asset_symbol"] == "ETH"]
+        ousdt_entries = [r for r in result if r["asset_symbol"] == "oUSDT"]
+        # ETH from SafeApi is preserved; backstop did not duplicate it.
+        assert len(eth_entries) == 1
+        assert (
+            eth_entries[0]["balance"] == 1_000_000_000_000_000
+        )  # SafeApi value, not 999
+        # oUSDT picked up by the backstop.
+        assert len(ousdt_entries) == 1
+        assert ousdt_entries[0]["balance"] == 5_000_000
+        # No other whitelisted token was added (all returned 0 on-chain).
+        assert sorted(symbols) == ["ETH", "oUSDT"]
 
 
 class TestSupplementWithOnchainWhitelistedBalances:
@@ -1167,7 +1199,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
         b._get_native_balance = _make_gen(123456)  # type: ignore[assignment,method-assign]
         b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         balances: list = []
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         native = [b for b in balances if b["asset_symbol"] == "ETH"]
         assert len(native) == 1
         assert native[0]["balance"] == 123456
@@ -1186,7 +1222,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
                 "balance": 100,
             }
         ]
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         eths = [b for b in balances if b["asset_symbol"] == "ETH"]
         assert len(eths) == 1
         assert eths[0]["balance"] == 100  # preserves SafeApi value
@@ -1197,7 +1237,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
         b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         b._get_token_balance = _make_gen(5_000_000)  # type: ignore[assignment,method-assign]
         balances: list = []
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         symbols = {b["asset_symbol"] for b in balances}
         assert "USDC" in symbols
 
@@ -1215,7 +1259,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
                 "balance": 42,
             }
         ]
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         usdc_entries = [b for b in balances if b["asset_symbol"] == "USDC"]
         assert len(usdc_entries) == 1
         assert usdc_entries[0]["balance"] == 42
@@ -1226,7 +1274,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
         b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         balances: list = []
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         assert balances == []
 
     def test_skips_when_get_token_balance_returns_none(self) -> None:
@@ -1235,7 +1287,11 @@ class TestSupplementWithOnchainWhitelistedBalances:
         b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         b._get_token_balance = _make_gen(None)  # type: ignore[assignment,method-assign]
         balances: list = []
-        _exhaust(b._supplement_with_onchain_whitelisted_balances("optimism", "0xsafe", balances))
+        _exhaust(
+            b._supplement_with_onchain_whitelisted_balances(
+                "optimism", "0xsafe", balances
+            )
+        )
         assert balances == []
 
 
@@ -1991,46 +2047,6 @@ class TestFetchRewardBalances:
         b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
         result = _exhaust(b._fetch_reward_balances("optimism"))
         assert result == []
-
-
-class TestFetchOusdtBalance:
-    """Test _fetch_ousdt_balance generator."""
-
-    def test_no_safe_address(self) -> None:
-        """Test no safe address."""
-        b = _make_behaviour()
-        b.params.safe_contract_addresses = {}
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
-
-    def test_positive_balance(self) -> None:
-        """Test positive balance."""
-        b = _make_behaviour()
-        b._get_token_balance = _make_gen(5000)  # type: ignore[assignment,method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is not None
-        assert result["asset_symbol"] == "oUSDT"
-        assert result["balance"] == 5000
-
-    def test_zero_balance(self) -> None:
-        """Test zero balance."""
-        b = _make_behaviour()
-        b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
-
-    def test_exception(self) -> None:
-        """Test exception."""
-        b = _make_behaviour()
-
-        def bad_gen(*a: Any, **kw: Any) -> Generator[Any, Any, Any]:
-            """Bad gen."""
-            raise Exception("fail")
-            yield  # noqa: unreachable
-
-        b._get_token_balance = bad_gen  # type: ignore[method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
 
 
 class TestAdjustPositions:
@@ -4226,45 +4242,6 @@ class TestGetLastKnownPrice:
         assert result is None
 
 
-class TestFetchOusdtBalanceNoSafe:
-    """Test _fetch_ousdt_balance."""
-
-    def test_no_safe_address(self) -> None:
-        """Test no safe address."""
-        b = _make_behaviour()
-        b.params.safe_contract_addresses = {}
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
-
-    def test_with_balance(self) -> None:
-        """Test with balance."""
-        b = _make_behaviour()
-        b._get_token_balance = _make_gen(1000)  # type: ignore[assignment,method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result["asset_symbol"] == "oUSDT"
-        assert result["balance"] == 1000
-
-    def test_zero_balance(self) -> None:
-        """Test zero balance."""
-        b = _make_behaviour()
-        b._get_token_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
-
-    def test_exception(self) -> None:
-        """Test exception."""
-        b = _make_behaviour()
-
-        def bad_balance(*a: Any, **kw: Any) -> Generator[Any, Any, Any]:
-            """Bad balance."""
-            raise Exception("fail")
-            yield  # noqa: unreachable
-
-        b._get_token_balance = bad_balance  # type: ignore[method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
-
-
 class TestGetServiceStakingState:
     """Test _get_service_staking_state."""
 
@@ -4888,23 +4865,6 @@ class TestExecuteStrategyIsolatedNamespace:
 
         # Verify the function was NOT injected into module globals
         assert method_name not in base_mod.__dict__
-
-
-class TestFetchOusdtBalanceExceptionInner:
-    """Test _fetch_ousdt_balance with exception during balance fetch."""
-
-    def test_exception_during_get_balance(self) -> None:
-        """Test exception during get balance."""
-        b = _make_behaviour()
-
-        def bad_gen(*a: Any, **kw: Any) -> Generator[Any, Any, Any]:
-            """Bad gen."""
-            raise Exception("contract error")
-            yield  # noqa: unreachable
-
-        b._get_token_balance = bad_gen  # type: ignore[method-assign]
-        result = _exhaust(b._fetch_ousdt_balance("optimism"))
-        assert result is None
 
 
 class TestAdjustCurrentPositionsFalseBranches:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -126,7 +126,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/liquidity_trader_abci:0.1.0:bafybeibr6rvadhhvvljiosmttsr4ctut7sxbpa72premlwbze5m6l545iy
+- valory/liquidity_trader_abci:0.1.0:bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 behaviours:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -126,7 +126,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/liquidity_trader_abci:0.1.0:bafybeicqcfn3viag3jgozv43ccgkrjm3zigyg6ln6sg6pjod3zcvsxgchy
+- valory/liquidity_trader_abci:0.1.0:bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 behaviours:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -126,7 +126,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/liquidity_trader_abci:0.1.0:bafybeic63kj4xmfljhthr2lgjm6nlilx6bambkmelts5qffdefvui2fgpu
+- valory/liquidity_trader_abci:0.1.0:bafybeiemdk35xt3qwrvly6il36qjfpe6lymhsqlatijqcn4bhpec7l32cy
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 behaviours:


### PR DESCRIPTION
## Summary

When SafeApi's Optimism balances endpoint is unavailable (e.g. monthly quota exceeded, transient indexing lag, or trusted-token list misses), the resulting `positions` array doesn't contain the safe's real holdings. Downstream consumers that read from `positions` then misbehave:

- **Investing**: `evaluate_strategy._get_available_tokens` (evaluate_strategy.py:2769) iterates `synchronized_data.positions`, sees only reward tokens + dust, logs `No tokens available for investment`, increments the strategy backoff counter, and the agent stops trying for 30 minutes to 4 hours per cycle.
- **Withdrawal**: `decision_making.fetch_routes` (decision_making.py:2580) calls `_get_balance(chain, from_token, positions)`, gets `None`, errors with `Could not determine available amount`, and marks the withdrawal `FAILED`.

This was the root cause behind several user support tickets this week (sc-8ce1d52f, sc-2655c77a, sc-8c5fdde5, plus an investing-stuck case). PR #281 added an on-chain backstop in the withdrawal swap *planner*, but not at the data source.

## What changed

Adds `_supplement_with_onchain_whitelisted_balances` in `base.py`. Called from `_get_optimism_balances_from_safe_api` right after the SafeApi parse and before `_fetch_reward_balances`. Mutates the `balances` list in place:

1. Reads native ETH via `_get_native_balance` and appends if missing.
2. Iterates `WHITELISTED_ASSETS[chain]` (USDC, USDT0, USDT, USDC.e, sDAI, oUSDT on Optimism), calls `_get_token_balance` on-chain for each, appends any non-zero balance not already in the result list.
3. Dedupes by lowercased address so SafeApi-returned values are preserved when both sources have an entry.

Reward tokens (OLAS, VELO) are unaffected — already covered by `_fetch_reward_balances`, which uses on-chain reads and runs unconditionally. The dedicated `_fetch_ousdt_balance` path is now also deduped against existing entries.

Result: `positions` reflects on-chain reality whenever SafeApi is unavailable, unblocking both the investment evaluator and the withdrawal executor without needing per-call-site patches.

## Tests

- 6 new tests in `TestSupplementWithOnchainWhitelistedBalances` cover: native ETH added when missing, ETH preserved when already present, whitelisted ERC20 added when missing, ERC20 not duplicated when already present (case-insensitive), zero balance skipped, RPC `None` skipped.
- 10 existing `TestGetOptimismBalances` tests updated to stub the new helper to a no-op so they keep testing their original intent.
- Full skill suite: 2850 tests pass.
- Production-replica script driven against the exact sc-8ce1d52f shape (SafeApi `(False, [])`, real on-chain balances mocked at the RPC boundary, real `_get_balance` consumer). Confirmed `positions` returns USDC + USDT + USDC.e + ETH instead of empty.

## Scope notes

- **Optimism only.** Mode's `_get_mode_balances_from_explorer_api` has its own native-ETH backstop but no whitelist backstop. Same helper would apply if Mode Explorer also goes flaky — easy follow-up, not in this PR.
- **Cost**: 6 extra RPC calls per `get_positions_round` for the whitelisted-token reads. On the happy path (SafeApi works), the dedup makes these confirming-zero checks, no behavioural change. Withdrawals happen infrequently and the investment round runs every few minutes, so the added cost is negligible.

## Test plan

- [ ] CI green (lint, mypy, pytest, coverage, package-hash check)
- [ ] Verify in a deployed agent: when SafeApi is unavailable, `get_positions_round` log shows the safe's on-chain stablecoin and ETH balances rather than empty positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)