### PR TITLE
feat(config): restore + extend named env vars in aea-config.yaml

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,8 +25,8 @@
         "connection/valory/mirror_db/0.1.0": "bafybeiasfxdd447vqut4uercswnn5pagy555oj2ws7deo2p7vnmq3mj64y",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiett4gnks5olb4zzgsyumcd5ytatqfrwec5a76uph7z3zok2ghjr4",
         "skill/valory/optimus_abci/0.1.0": "bafybeibxcsqg5r6bo2v6wmekepmw6gda75cvqohfrdjyyvasjrdx67wqgq",
-        "agent/valory/optimus/0.1.0": "bafybeievffp7fft2upenrkcfjevmwehi3nl4n3vurnwxovnryucvwkerti",
-        "service/valory/optimus/0.1.0": "bafybeidutvl4k3zg2obptloa2lp3d2ro4xh7kun64eai5d2niwib5lmjmu"
+        "agent/valory/optimus/0.1.0": "bafybeiavtoxghlfz5li4hw76wyl57g42bk7pvfjjfk3pbqoeu3qtqvmwae",
+        "service/valory/optimus/0.1.0": "bafybeic4yof22rkygd4qpsbbjsc44ixkrhxo2omefbujvc4ecbmoae5akq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -81,10 +81,10 @@ logging_config:
     logfile:
       class: logging.handlers.RotatingFileHandler
       formatter: standard
-      filename: ${str:log.txt}
-      level: ${str:INFO}
-      maxBytes: ${int:52428800}
-      backupCount: ${int:1}
+      filename: ${LOG_FILE:str:log.txt}
+      level: ${LOG_LEVEL:str:INFO}
+      maxBytes: ${LOG_MAX_BYTES:int:52428800}
+      backupCount: ${LOG_BACKUP_COUNT:int:1}
     console:
       class: logging.StreamHandler
       formatter: standard
@@ -104,7 +104,7 @@ default_connection: null
 public_id: valory/kv_store:0.1.0
 type: connection
 config:
-  store_path: ${str:/data}
+  store_path: ${STORE_PATH:str:/data}
 ---
 public_id: valory/mirror_db:0.1.0
 type: connection
@@ -139,7 +139,7 @@ config:
       poa_chain: ${bool:false}
       default_gas_price_strategy: ${str:eip1559}
     mode:
-      address: ${str:https://mainnet.mode.network/}
+      address: ${MODE_LEDGER_RPC:str:https://mainnet.mode.network/}
       chain_id: ${int:34443}
       poa_chain: ${bool:false}
       default_gas_price_strategy: ${str:eip1559}
@@ -182,7 +182,7 @@ models:
     args:
       fund_requirements: ${dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
       rpc_urls: ${dict:{"optimism":"https://mainnet.optimism.io"}}
-      safe_contract_addresses: ${dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
+      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection
@@ -197,12 +197,12 @@ type: skill
 models:
   benchmark_tool:
     args:
-      log_dir: ${str:/logs}
+      log_dir: ${LOG_DIR:str:/logs}
   coingecko:
     args:
       token_price_endpoint: ${str:/api/v3/simple/token_price/{asset_platform_id}?contract_addresses={token_address}&vs_currencies=usd}
       coin_price_endpoint: ${str:/api/v3/simple/price?ids={coin_id}&vs_currencies=usd}
-      api_key: ${str:null}
+      api_key: ${COINGECKO_API_KEY:str:null}
       requests_per_minute: ${int:30}
       credits: ${int:10000}
       rate_limited_code: ${int:429}
@@ -254,7 +254,7 @@ models:
       service_id: optimus
       service_registry_address: ${str:null}
       setup:
-        all_participants: ${list:["0x0000000000000000000000000000000000000000"]}
+        all_participants: ${ALL_PARTICIPANTS:list:["0x0000000000000000000000000000000000000000"]}
         consensus_threshold: ${int:null}
         safe_contract_address: ${str:0x0000000000000000000000000000000000000000}
       share_tm_config_on_startup: ${bool:false}
@@ -277,7 +277,7 @@ models:
       termination_from_block: ${int:34088325}
       allowed_dexs: ${list:["balancerPool", "UniswapV3", "velodrome"]}
       initial_assets: ${str:{"mode":{"0x0000000000000000000000000000000000000000":"ETH","0xd988097fb8612cc24eeC14542bC03424c656005f":"USDC"}}}
-      safe_contract_addresses: ${str:{"ethereum":"0x0000000000000000000000000000000000000000","base":"0x0000000000000000000000000000000000000000","optimism":"0x0000000000000000000000000000000000000000","mode":"0x0000000000000000000000000000000000000000"}}
+      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:str:{"ethereum":"0x0000000000000000000000000000000000000000","base":"0x0000000000000000000000000000000000000000","optimism":"0x0000000000000000000000000000000000000000","mode":"0x0000000000000000000000000000000000000000"}}
       merkl_fetch_campaigns_args: ${str:{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}}
       allowed_chains: ${list:["mode"]}
       gas_reserve: ${str:{"ethereum":1000,"optimism":1000,"base":1000}}
@@ -307,7 +307,7 @@ models:
       staking_token_contract_address: ${str:0x88996bbdE7f982D93214881756840cE2c77C4992}
       staking_activity_checker_contract_address: ${str:0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68}
       staking_threshold_period: ${int:5}
-      store_path: ${str:/data}
+      store_path: ${STORE_PATH:str:/data}
       assets_info_filename: ${str:assets.json}
       pool_info_filename: ${str:current_pool.json}
       portfolio_info_filename: ${str:portfolio.json}
@@ -318,9 +318,9 @@ models:
       max_fee_percentage: ${float:0.02}
       max_gas_percentage: ${float:0.25}
       balancer_graphql_endpoints: ${str:{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}}
-      target_investment_chains: ${list:["optimism"]}
+      target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["optimism"]}
       staking_chain: ${str:optimism}
-      file_hash_to_strategies: ${str:{"bafybeie4sceuc3z52jqtnsn5knnsjeogu6gsnetvp325ao2tf4vv3dqcee":"max_apr_selection","bafybeihixbkln3gvgoqml2lboazujtdgzvopeqrgwkfsidhkdj2etrni7a":"balancer_pools_search","bafybeihida2j22vumxowkg5hsz7a7ntkiwv25r3oefwfxecxdrvmsfv6hy":"uniswap_pools_search","bafybeic74xaoypdx3npk6i5h7tadqcsxvdegtuebcic3kz5baqaddqt4vm":"asset_lending","bafybeicytgrvg2j25cqywf37p2yjw726brceutil3f52y2twp4x643axae":"velodrome_pools_search"}}
+      file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:str:{"bafybeie4sceuc3z52jqtnsn5knnsjeogu6gsnetvp325ao2tf4vv3dqcee":"max_apr_selection","bafybeihixbkln3gvgoqml2lboazujtdgzvopeqrgwkfsidhkdj2etrni7a":"balancer_pools_search","bafybeihida2j22vumxowkg5hsz7a7ntkiwv25r3oefwfxecxdrvmsfv6hy":"uniswap_pools_search","bafybeic74xaoypdx3npk6i5h7tadqcsxvdegtuebcic3kz5baqaddqt4vm":"asset_lending","bafybeicytgrvg2j25cqywf37p2yjw726brceutil3f52y2twp4x643axae":"velodrome_pools_search"}}
       strategies_kwargs: ${str:{"merkl_pools_search":{"balancer_graphql_endpoints":{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"},"merkl_fetch_campaign_args":{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}},"uniswap_pools_search":{"graphql_endpoints":{"optimism":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5","base":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/GqzP4Xaehti8KSfQmv3ZctFSjnSUYZ4En5NRsiTbvZpz"}},"balancer_pools_search":{"graphql_endpoint":"https://api-v3.balancer.fi/"},"velodrome_pools_search":{"graphql_endpoint":"https://gateway.thegraph.com/api/b8e4cf1b314c67d2a0109325046a7464/subgraphs/id/7tA4PY1VmbycJeoVtn2mjQK4NbozgwTuZgrxDTxzEDL1"},"asset_lending":{"endpoint":"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/v2Aggregators","lending_asset":"0x4200000000000000000000000000000000000006"}}}
       available_protocols: ${list:["VELODROME"]}
       selected_hyper_strategy: ${str:max_apr_selection}
@@ -337,7 +337,7 @@ models:
       x402_payment_requirements: ${str:{"threshold":200000,"topup":250000}}
       optimism_ledger_rpc: ${str:https://mainnet.optimism.io}
       lifi_quote_to_amount_url: ${str:https://li.quest/v1/quote/toAmount}
-      tls_verify: ${bool:true}
-      mode_conduit_explorer_url: ${str:https://explorer-mode-mainnet-0.t.conduit.xyz/api/v2}
-      safe_api_v1_url: ${str:https://safe-transaction-optimism.safe.global/api/v1}
-      mode_native_explorer_url: ${str:https://explorer.mode.network/api}
+      tls_verify: ${TLS_VERIFY:bool:true}
+      mode_conduit_explorer_url: ${MODE_CONDUIT_EXPLORER_URL:str:https://explorer-mode-mainnet-0.t.conduit.xyz/api/v2}
+      safe_api_v1_url: ${SAFE_API_V1_URL:str:https://safe-transaction-optimism.safe.global/api/v1}
+      mode_native_explorer_url: ${MODE_NATIVE_EXPLORER_URL:str:https://explorer.mode.network/api}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeievffp7fft2upenrkcfjevmwehi3nl4n3vurnwxovnryucvwkerti
+agent: valory/optimus:0.1.0:bafybeiavtoxghlfz5li4hw76wyl57g42bk7pvfjjfk3pbqoeu3qtqvmwae
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Re-applies the named `${VAR:type:default}` syntax to `packages/valory/agents/optimus/aea-config.yaml`, **plus** names new operator-tunable parameters added since the original work.

The original named-env-var work (commit `8e401433`, PR #266 follow-up) was reverted in `4254a296` because open-autonomy and the middleware lacked support at the time; both have since shipped that support. `service.yaml` overrides have already been carrying named vars.

**Restored (originally named, then reverted):** 13 vars — LOG_*, STORE_PATH, MODE_LEDGER_RPC, COINGECKO_API_KEY, ALL_PARTICIPANTS, SAFE_CONTRACT_ADDRESSES, LOG_DIR, TARGET_INVESTMENT_CHAINS.

**Newly named (added to agent after the original PR):**
- `FILE_HASH_TO_STRATEGIES`
- `MODE_CONDUIT_EXPLORER_URL`
- `MODE_NATIVE_EXPLORER_URL`
- `SAFE_API_V1_URL`
- `TLS_VERIFY`

**Intentionally left anonymous:** framework/protocol internals (Tendermint timeouts, consensus settings, HTTP method strings, fixed protocol addresses).

Hashes re-locked via `autonomy packages lock`.

## Test plan

- [x] `tomte tox -e check-hash`, `check-packages`
- [x] `tomte tox -e check-abciapp-specs`, `check-handlers`
- [x] `tomte tox -e check-dependencies`, `check-third-party-hashes`
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e darglint`, `pylint`
- [x] `tomte tox -p -e safety -e bandit`
- [x] gitleaks — fails the same way on `origin/main` (pre-existing UI build artifacts), unrelated to this PR
- [ ] Smoke-test agent run to confirm middleware resolves the named vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)