### PR TITLE
chore(deps): bump idna past 3.15 patched window

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1738,11 +1738,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `idna` from 3.13 to 3.17 via `uv lock --upgrade-package idna`. The 3.15 release tightens early-rejection on long inputs to `idna.encode()`; bumping past it closes [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx).
- `idna` is a transitive dep — pulled in by `requests`, `anyio`, and `yarl`, all of which sit on the production install path. No direct pin existed in `pyproject.toml`, so the bump is lock-only and touches one package; 159 of the 160 resolved packages are unchanged.
- Closes #324.

## Test plan

- [ ] CI green on this branch
- [ ] `tox -e py3.10-darwin` / `py3.10-linux` (unit + integration)
- [ ] `make code-checks` and `make common-checks-1` / `common-checks-2` pass
- [ ] Confirm `autonomy packages lock --check` is still clean (no `packages/` content moved, so should be a no-op)
- [ ] Confirm the open Dependabot alert at `/security/dependabot/86` auto-closes after the merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)