### PR TITLE
fix: check-agent-runner overrides via named env var STORE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,9 +212,11 @@ build-agent-runner-mac: uv-install  agent
 
 .PHONY: check-agent-runner
 check-agent-runner:
-	# aea-config.yaml uses anonymous templates ($${str:/data}) so Pearl's
-	# path-based env-var injection wins at runtime; a named template would
-	# suppress the fallback. See valory-xyz/olas-operate-middleware#424.
+	# aea-config.yaml uses named env-var templates ($${STORE_PATH:str:/data})
+	# for both the kv_store connection and the optimus_abci skill params,
+	# so a single STORE_PATH override drives both. Path-based env vars
+	# (CONNECTION_..._STORE_PATH / SKILL_..._STORE_PATH) are silently
+	# ignored when the template carries an explicit name — open-aea's
+	# apply_env_variables only consults the named key.
 	uv run aea-helpers check-binary ./dist/agent_runner_bin$(EXE_SUFFIX) ./agent \
-	--env-var CONNECTION_KV_STORE_CONFIG_STORE_PATH=$(STORE_PATH_VALUE) \
-	--env-var SKILL_OPTIMUS_ABCI_MODELS_PARAMS_ARGS_STORE_PATH=$(STORE_PATH_VALUE)
+	--env-var STORE_PATH=$(STORE_PATH_VALUE)


### PR DESCRIPTION
## Summary

Restores the named `--env-var STORE_PATH=$(STORE_PATH_VALUE)` injection in the `check-agent-runner` Makefile target. The current path-based injection (`CONNECTION_KV_STORE_CONFIG_STORE_PATH`, `SKILL_OPTIMUS_ABCI_MODELS_PARAMS_ARGS_STORE_PATH`) is silently dropped by open-aea's `apply_env_variables` because `aea-config.yaml` carries **named** templates (`${STORE_PATH:str:/data}`) for both the `kv_store` connection and the `optimus_abci` skill params — named templates only consult the named env key, never the path-derived one.

## Why this regressed

- `aea-config.yaml` was flipped back to named env-var templates in commit `46869e4d`
- The matching Makefile change to inject the named `STORE_PATH` (originally landed in `f88cf5c0`) was not carried along
- `check-agent-runner` lives in `.github/workflows/release.yaml` and only fires on `release` events, so the regression slipped through every PR-level CI run between then and now

## Concrete symptom

v0.10.1 release workflow `build-agent-runner` jobs all fail at the `check agent runner` step:

```
Error: An error occurred during instantiation of connection valory/kv_store:0.1.0/KvStoreConnection:
Traceback (most recent call last):
  File "pathlib.py", line 1175, in mkdir
PermissionError: [Errno 13] Permission denied: '/data'
[FAIL] Did not find 'Starting AEA' within 80s
make: *** [Makefile:218: check-agent-runner] Error 1
```

Because `STORE_PATH` is never set in CI, the template default `/data` bubbles through and `KvStoreConnection.__init__` hits the unwritable root path on the runner.

## Fix

- Drop the two path-based `--env-var` overrides
- Replace with `--env-var STORE_PATH=$(STORE_PATH_VALUE)` (the same single var drives both the connection and the skill since they share the same named template)
- Update the stale comment that still described the anonymous-template state

## Test plan

- [ ] Once merged, re-cut a release tag (e.g. `v0.10.2`) or re-run the v0.10.1 release workflow and verify `build-agent-runner` reaches "Starting AEA" before the 80s deadline on all OS / Python matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)