### PR TITLE
fix(config): revert named ALL_PARTICIPANTS env var on optimus aea-config

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,8 +24,8 @@
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeieadtlwtfbwb7hjvoedvavddwufstbvbdke2nvbvhh62wzwwkctdi",
         "skill/valory/optimus_abci/0.1.0": "bafybeihxbgpptcmy4qnnkszlm3cuosnu3lkt6oiv4txxibqsgyg2hbn5be",
-        "agent/valory/optimus/0.1.0": "bafybeia4dmcsbnkax4ppprrn3nzqsucp4bygvk5qiiul6fqgdm36q4atwe",
-        "service/valory/optimus/0.1.0": "bafybeih5vovfkjrh7iajg25gkxcgrdl3ai2c4qg7ewvwu2kmvjiuipnjfm"
+        "agent/valory/optimus/0.1.0": "bafybeigom6mach6k4idybv7ugwbotxb44pthc3bkerxe7l36s3ikwgkjja",
+        "service/valory/optimus/0.1.0": "bafybeigc77ps4pbrbjjeyeipe5gk4zp66sv2rlvgead2ccaxejqqzjlkx4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -248,7 +248,7 @@ models:
       service_id: optimus
       service_registry_address: ${str:null}
       setup:
-        all_participants: ${ALL_PARTICIPANTS:list:["0x0000000000000000000000000000000000000000"]}
+        all_participants: ${list:["0x0000000000000000000000000000000000000000"]}
         consensus_threshold: ${int:null}
         safe_contract_address: ${str:0x0000000000000000000000000000000000000000}
       share_tm_config_on_startup: ${bool:false}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeia4dmcsbnkax4ppprrn3nzqsucp4bygvk5qiiul6fqgdm36q4atwe
+agent: valory/optimus:0.1.0:bafybeigom6mach6k4idybv7ugwbotxb44pthc3bkerxe7l36s3ikwgkjja
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Reverts a single line introduced by PR #322 (commit \`46869e4d\`) that broke Pearl deployments of optimus. The agent's \`aea-config.yaml\` line 251 goes back from named to anonymous:

\`\`\`diff
-        all_participants: \${ALL_PARTICIPANTS:list:["0x0000000000000000000000000000000000000000"]}
+        all_participants: \${list:["0x0000000000000000000000000000000000000000"]}
\`\`\`

## Symptom

On Pearl main, the optimus agent log shows ~1000 occurrences of:

\`\`\`
TransactionNotValidError: 0xE5F4346e07b628AF86cB12175a573F51275A7b8b
  not in list of participants: ['0x0000000000000000000000000000000000000000']
\`\`\`

The participants list is the zero-address YAML default from \`aea-config.yaml\` line 251, which means the value Pearl computes for the agent never reaches the agent process.

## Root cause

PR #322 relied on open-autonomy 0.21.22's new \`AutonomyService._extract_named_env_var_defaults\`. That helper walks the service overrides, finds \`\${NAME:type:default}\` placeholders that survive into the deployment build, and writes them into \`agent.json\` as named keys. Combined with operate-app's \`env_variables\` (\`SAFE_CONTRACT_ADDRESSES\`, \`STORE_PATH\`, etc.), most named templates land their values correctly.

\`all_participants\` does not. Pearl plumbs it through \`ServiceBuilder.try_update_runtime_params\`, which mutates \`service.overrides\` in memory and **replaces the template string with the literal address list** before the OA extractor runs. By that point there is no \`\${ALL_PARTICIPANTS:...}\` string for the extractor to find, so no \`ALL_PARTICIPANTS\` named key lands in \`agent.json\`. The agent only sees the path-based \`SKILL_OPTIMUS_ABCI_..._ALL_PARTICIPANTS\` key, and open-aea ignores the path-based fallback once the template is named-form. So the agent falls back to the YAML default (zero-address list) and the consensus round rejects the real agent.

## Why only this line

Of the 14 lines PR #322 named:

- \`SAFE_CONTRACT_ADDRESSES\`, \`STORE_PATH\`, \`MODE_LEDGER_RPC\`, \`LOG_DIR\`, \`COINGECKO_API_KEY\`, \`TARGET_INVESTMENT_CHAINS\`: declared in operate-app's \`env_variables\`, bridged via the OA extractor. Verified working on a current-main Pearl run (real safe address, real persistent_data path).
- \`LOG_FILE\`, \`LOG_LEVEL\`, \`TLS_VERIFY\`, \`FILE_HASH_TO_STRATEGIES\`, \`MODE_CONDUIT_EXPLORER_URL\`, \`SAFE_API_V1_URL\`, \`MODE_NATIVE_EXPLORER_URL\`: not overridden by Pearl. The YAML default is the intended value.
- \`ALL_PARTICIPANTS\`: this PR.

The other two setup-block fields driven by \`try_update_runtime_params\` (\`safe_contract_address\`, \`consensus_threshold\`) were left anonymous in PR #322 and continue to work.

## Follow-up

The durable fix lives in olas-operate-middleware. Teach \`try_update_runtime_params\` (or OA's extraction step) to also push the resolved value as a named key when it rewrites the override, so named templates for runtime-param fields become safe. Once that lands, \`all_participants\` can go back to the named form.

## Test plan
- [ ] Pearl smoke test on optimus: confirm \`TransactionNotValidError\` is gone and consensus proceeds with the real agent address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)