### PR TITLE
feat(safety): re-enable profitability gate + add swap slippage cap (WS2 2.5/2.6)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,10 +22,10 @@
         "contract/valory/velodrome_voter/0.1.0": "bafybeieawpdivhzrbjk6ivsrncxah5y5gbb32qxmrcb2dxmw55ev7gowda",
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta",
-        "skill/valory/optimus_abci/0.1.0": "bafybeic5qrtl7zgyqp3jjriaaf3bppijo33lfzps6mbgeydlsftoy7cnfy",
-        "agent/valory/optimus/0.1.0": "bafybeicu4cu2sldqmluyqg2nxa45zsp2hxyet7ryl4lh3tgaccfbyavhbe",
-        "service/valory/optimus/0.1.0": "bafybeiapjamuak55lcztkxu46hgdrfnxvrnarf2vvps7rc3fhxejuge4gu"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeidv4pgnz53vsafcianlm6wzxe3bl26ohfiasgkw4hsm57ap6qoaxq",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiabgfibrxuk5fc2i6ex5rugz34w27iufznwgpm6mk342t4fg2bpfu",
+        "agent/valory/optimus/0.1.0": "bafybeiaspcsi72v37xd6q7kycjm6x3g2o3ya5jhbojpewygca6muheuoci",
+        "service/valory/optimus/0.1.0": "bafybeia5nzyf5nzyfgwgknlvvhw6erhlegclyne2mmjxl6onef5fud77ze"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,10 +22,10 @@
         "contract/valory/velodrome_voter/0.1.0": "bafybeieawpdivhzrbjk6ivsrncxah5y5gbb32qxmrcb2dxmw55ev7gowda",
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeic6n6nazlkvdutgglhnrjfjt7lyenm2gad3xqljgjs2kafvszwsea",
-        "skill/valory/optimus_abci/0.1.0": "bafybeigz327hmtc652pouc62wuuq3nf6tmfzrx7z7svajubwcglgmbnrbi",
-        "agent/valory/optimus/0.1.0": "bafybeiev3v5ke2tbnz66u7bzonhku7n5v3saacxgfhojbs3uehavwbi5da",
-        "service/valory/optimus/0.1.0": "bafybeiezv65m7epwsdozd2wdu6sfltqicoab3ho36xexv5kwii3u6ioxim"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta",
+        "skill/valory/optimus_abci/0.1.0": "bafybeic5qrtl7zgyqp3jjriaaf3bppijo33lfzps6mbgeydlsftoy7cnfy",
+        "agent/valory/optimus/0.1.0": "bafybeicu4cu2sldqmluyqg2nxa45zsp2hxyet7ryl4lh3tgaccfbyavhbe",
+        "service/valory/optimus/0.1.0": "bafybeiapjamuak55lcztkxu46hgdrfnxvrnarf2vvps7rc3fhxejuge4gu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -51,8 +51,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta
-- valory/optimus_abci:0.1.0:bafybeic5qrtl7zgyqp3jjriaaf3bppijo33lfzps6mbgeydlsftoy7cnfy
+- valory/liquidity_trader_abci:0.1.0:bafybeidv4pgnz53vsafcianlm6wzxe3bl26ohfiasgkw4hsm57ap6qoaxq
+- valory/optimus_abci:0.1.0:bafybeiabgfibrxuk5fc2i6ex5rugz34w27iufznwgpm6mk342t4fg2bpfu
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -311,6 +311,7 @@ models:
       min_investment_amount: ${int:1}
       max_fee_percentage: ${float:0.02}
       max_gas_percentage: ${float:0.25}
+      max_slippage_percentage: ${float:0.1}
       balancer_graphql_endpoints: ${str:{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["optimism"]}
       staking_chain: ${str:optimism}

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -51,8 +51,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeic6n6nazlkvdutgglhnrjfjt7lyenm2gad3xqljgjs2kafvszwsea
-- valory/optimus_abci:0.1.0:bafybeigz327hmtc652pouc62wuuq3nf6tmfzrx7z7svajubwcglgmbnrbi
+- valory/liquidity_trader_abci:0.1.0:bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta
+- valory/optimus_abci:0.1.0:bafybeic5qrtl7zgyqp3jjriaaf3bppijo33lfzps6mbgeydlsftoy7cnfy
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeicu4cu2sldqmluyqg2nxa45zsp2hxyet7ryl4lh3tgaccfbyavhbe
+agent: valory/optimus:0.1.0:bafybeiaspcsi72v37xd6q7kycjm6x3g2o3ya5jhbojpewygca6muheuoci
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeiev3v5ke2tbnz66u7bzonhku7n5v3saacxgfhojbs3uehavwbi5da
+agent: valory/optimus:0.1.0:bafybeicu4cu2sldqmluyqg2nxa45zsp2hxyet7ryl4lh3tgaccfbyavhbe
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -93,6 +93,7 @@ models:
       min_investment_amount: ${MIN_INVESTMENT_AMOUNT:int:1}
       max_fee_percentage: ${MAX_FEE_PERCENTAGE:float:0.02}
       max_gas_percentage: ${MAX_GAS_PERCENTAGE:float:0.25}
+      max_slippage_percentage: ${MAX_SLIPPAGE_PERCENTAGE:float:0.1}
       balancer_graphql_endpoints: ${BALANCER_GRAPHQL_ENDPOINTS:str:{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}}
       allowed_chains: ${ALLOWED_CHAINS:list:["base","optimism","mode"]}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["base","optimism","mode"]}
@@ -111,7 +112,7 @@ models:
       genai_api_key: ${GENAI_API_KEY:str:""}
       airdrop_started: ${AIRDROP_STARTED:bool:false}
       airdrop_contract_address: ${AIRDROP_CONTRACT_ADDRESS:str:""}
-      slippage_tolerance: ${SLIPPAGE_TOLERANCE:float:1.0}
+      slippage_tolerance: ${SLIPPAGE_TOLERANCE:float:0.01}
       genai_model: ${GENAI_MDOEL:str:gemini-2.5-flash}
       slippage_for_swap: ${SLIPPAGE_FOR_SWAP:float:0.005}
       use_x402: ${USE_X402:bool:true}

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
@@ -2239,9 +2239,32 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
             f"Details: total_fee={total_fee}, total_gas_cost={total_gas_cost}, from_amount_usd={from_amount_usd}, to_amount_usd={to_amount_usd}"
         )
 
-        # TEMP (Basius MVP): profitability gate bypassed, re-enable per
-        # workstream 2 PR 2.6 by gating on fee_percentage/gas_percentage
-        # against allowed_fee_percentage/allowed_gas_percentage.
+        if (
+            fee_percentage > allowed_fee_percentage
+            or gas_percentage > allowed_gas_percentage
+        ):
+            self.context.logger.error(
+                f"Route is not profitable: fee {fee_percentage:.2f}% "
+                f"(allowed {allowed_fee_percentage:.2f}%), gas {gas_percentage:.2f}% "
+                f"(allowed {allowed_gas_percentage:.2f}%)"
+            )
+            return False, None, None
+
+        # Combined value-loss cap: (fromAmountUSD - toAmountUSD) / fromAmountUSD bounds the
+        # total value lost on the route. LiFi's toAmountUSD is net of protocol/integrator
+        # fees, so this captures fees + price impact together (an agent-side backstop
+        # independent of LiFi's own slippage param) — it is NOT market slippage alone, and
+        # can fire even when the fee/gas gates above pass.
+        slippage_percentage = (
+            (from_amount_usd - to_amount_usd) / from_amount_usd
+        ) * 100
+        allowed_slippage_percentage = self.params.max_slippage_percentage * 100
+        if slippage_percentage > allowed_slippage_percentage:
+            self.context.logger.error(
+                f"Route slippage too high: {slippage_percentage:.2f}% of input "
+                f"(allowed {allowed_slippage_percentage:.2f}%)"
+            )
+            return False, None, None
 
         self.context.logger.info("Route is profitable!")
         return True, total_fee, total_gas_cost

--- a/packages/valory/skills/liquidity_trader_abci/models.py
+++ b/packages/valory/skills/liquidity_trader_abci/models.py
@@ -479,6 +479,11 @@ class Params(BaseParams):
         self.min_investment_amount = self._ensure("min_investment_amount", kwargs, int)
         self.max_fee_percentage = self._ensure("max_fee_percentage", kwargs, float)
         self.max_gas_percentage = self._ensure("max_gas_percentage", kwargs, float)
+        # Stored as a FRACTION (0.1 == 10%), not a percent — multiplied by 100 at the
+        # use-site. Matches max_fee_percentage / max_gas_percentage above.
+        self.max_slippage_percentage = self._ensure(
+            "max_slippage_percentage", kwargs, float
+        )
         self.balancer_graphql_endpoints = json.loads(
             self._ensure("balancer_graphql_endpoints", kwargs, str)
         )

--- a/packages/valory/skills/liquidity_trader_abci/models.py
+++ b/packages/valory/skills/liquidity_trader_abci/models.py
@@ -481,6 +481,12 @@ class Params(BaseParams):
         self.max_gas_percentage = self._ensure("max_gas_percentage", kwargs, float)
         # Stored as a FRACTION (0.1 == 10%), not a percent — multiplied by 100 at the
         # use-site. Matches max_fee_percentage / max_gas_percentage above.
+        # NOTE: this gate bounds COMBINED value loss (fromAmountUSD - toAmountUSD), which
+        # includes protocol/integrator fees as well as price impact, so it overlaps the
+        # fee gate. Set it with max_fee_percentage + max_gas_percentage headroom in mind:
+        # a route at the fee/gas limits already reports ~that much value loss here even at
+        # zero price impact, so a value too close to those limits rejects otherwise-fine
+        # routes. See check_if_route_is_profitable for the use-site.
         self.max_slippage_percentage = self._ensure(
             "max_slippage_percentage", kwargs, float
         )

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -23,7 +23,7 @@ fingerprint:
   handlers.py: bafybeigxkxtlzq53eedt3ig27gmyarv7gd63p2dgzi3oqdnyuyjhiffzqi
   io_/__init__.py: bafybeiemrhqu7ii7n7c63x26jxiwer7a545eanfcqgasbqe7wb7b3ynvmi
   io_/loader.py: bafybeictieroff4sy6qgc6zm2vfnzhoeqwfz4k5cb4ccfsaajxzlnqkoae
-  models.py: bafybeihm2qzqvvlnnpxzwyf5sapiawelndohktjz7sjdgta7jwveih4vgm
+  models.py: bafybeihz42wusni5urkw64t7gftfsg3xw37fuez36zfbzfmvzvmtexosty
   payloads.py: bafybeifrnypndloixuq3tmpim6fhte26srsc6zhrpm4rp45hjib6k6ogdq
   pool_behaviour.py: bafybeidpz4kqbl5fpt2rtlmmdamnujbqu7rpdx726ntgsqsgeivwz3ylsu
   pools/__init__.py: bafybeigfi5svtn2csdf2nna6cfonjx7abkkwvfyt3sqmmtbcxvrv5vykpy
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeifeds2sqspatms4r5ereixkbkthxhonptc52ettf33p4pljybmv5m
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidv7ckk3qqyovnynl5v7nuxwzbols7jkhkrtiwa3uv7lxi4nykqtm
-  tests/behaviours/test_decision_making.py: bafybeib6if3k63uknuvl7kmag7l5wjc66osvgmfjqgqjsnzjzwebcpifwa
+  tests/behaviours/test_decision_making.py: bafybeighgbljrovh4klaeyrqymlvlncqrw7f66qmmwhuhvcsngkcy34vty
   tests/behaviours/test_evaluate_strategy.py: bafybeicd73ykx3gtfp77yv6er63ixyf2wj2cruravzrglxd2mwnlef3nce
   tests/behaviours/test_fetch_strategies.py: bafybeicngxpu3hfq5cxzxpuvoiayv4trol6pwj634vw3suoj4frofgleuq
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -291,6 +291,7 @@ models:
       min_investment_amount: 1
       max_fee_percentage: 0.02
       max_gas_percentage: 0.1
+      max_slippage_percentage: 0.1
       balancer_graphql_endpoints: '{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}'
       target_investment_chains:
       - base

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -11,7 +11,7 @@ fingerprint:
   behaviours/base.py: bafybeiejlh2h5bghlznaisw26p3km3e4cis3i5u4alul2e42bhzxsjveoe
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeieidx73vhcck7i3o2wkr435tarz5ikl4sogopgocg5quakgtf3csy
-  behaviours/decision_making.py: bafybeiemvgc2np3f26mm72mjawckzzkzrpfvajs5jz7cbahdc6a5q3i3by
+  behaviours/decision_making.py: bafybeifulwp6s3qzsah6t2h7oixm4mto2nkj76xpbkxjgk4cqedkoi372y
   behaviours/evaluate_strategy.py: bafybeic3c6k2szdievyefustltvbnpw6gywd5iuwmapowjam5kptrhkyna
   behaviours/fetch_strategies.py: bafybeihcvc4waghcybranmntytziqirjx5glu5zrmv7p6lzh77xhnp2ei4
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
@@ -23,7 +23,7 @@ fingerprint:
   handlers.py: bafybeigxkxtlzq53eedt3ig27gmyarv7gd63p2dgzi3oqdnyuyjhiffzqi
   io_/__init__.py: bafybeiemrhqu7ii7n7c63x26jxiwer7a545eanfcqgasbqe7wb7b3ynvmi
   io_/loader.py: bafybeictieroff4sy6qgc6zm2vfnzhoeqwfz4k5cb4ccfsaajxzlnqkoae
-  models.py: bafybeial2s46bh3xmokm5du2d7rbyyiuuubbxk7bdad5gluz7i55ybv5qi
+  models.py: bafybeihm2qzqvvlnnpxzwyf5sapiawelndohktjz7sjdgta7jwveih4vgm
   payloads.py: bafybeifrnypndloixuq3tmpim6fhte26srsc6zhrpm4rp45hjib6k6ogdq
   pool_behaviour.py: bafybeidpz4kqbl5fpt2rtlmmdamnujbqu7rpdx726ntgsqsgeivwz3ylsu
   pools/__init__.py: bafybeigfi5svtn2csdf2nna6cfonjx7abkkwvfyt3sqmmtbcxvrv5vykpy
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeifeds2sqspatms4r5ereixkbkthxhonptc52ettf33p4pljybmv5m
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidv7ckk3qqyovnynl5v7nuxwzbols7jkhkrtiwa3uv7lxi4nykqtm
-  tests/behaviours/test_decision_making.py: bafybeidmi7d6qxdhqvl6alcknlvw3g4bx2gcjiqb45ddemdnckabdbbila
+  tests/behaviours/test_decision_making.py: bafybeib6if3k63uknuvl7kmag7l5wjc66osvgmfjqgqjsnzjzwebcpifwa
   tests/behaviours/test_evaluate_strategy.py: bafybeicd73ykx3gtfp77yv6er63ixyf2wj2cruravzrglxd2mwnlef3nce
   tests/behaviours/test_fetch_strategies.py: bafybeicngxpu3hfq5cxzxpuvoiayv4trol6pwj634vw3suoj4frofgleuq
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu
@@ -76,7 +76,7 @@ fingerprint:
   tests/test___init__.py: bafybeicv7zly4wifncnlfzbdjebvdacb5ovogo677elvamntrb23ea3hl4
   tests/test_dialogues.py: bafybeigxvkwchtbxlelauxdqug2eayeiafxcyrxxpzfwzqztcytf3l4zk4
   tests/test_handlers.py: bafybeieytuiapfnjeu5t2xrz6n6rvijuml3buyxvm4snqluooymtvuuj5i
-  tests/test_models.py: bafybeiblzt223iwel75usiox5hum5pyocusj7f4rgq4at7scmme4u5gq7a
+  tests/test_models.py: bafybeic5k7gajtyvwcir3tf3w6nsmel4eahhb6jrf5ud23ltkp2tfp36ui
   tests/test_payloads.py: bafybeihgckap5l6g7gmj2g7bon4zp5oc23mo55pt32hstznwobfb24cifq
   tests/test_pool_behaviour.py: bafybeifjmzgidcgv33kph6dspm5stlunwxb3qbmczhppcxq52v4rorurlu
   tests/test_rounds.py: bafybeihkb4qxrwbmdnointbjelwttrw6styzs4rodmlbcnnaglvvqkczom

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -62,8 +62,10 @@ def _make_behaviour(**overrides: Any) -> DecisionMakingBehaviour:
     params.lifi_fetch_step_transaction_url = "https://li.fi/step"
     params.lifi_advance_routes_url = "https://li.fi/routes"
     params.waiting_period_for_status_check = 0
-    params.max_fee_percentage = 0.05
-    params.max_gas_percentage = 0.05
+    # Distinct so a production-side threshold swap (fee checked against the gas limit
+    # or vice-versa) is observable in TestCheckIfRouteIsProfitable.
+    params.max_fee_percentage = 0.05  # 5%
+    params.max_gas_percentage = 0.25  # 25%
     params.max_slippage_percentage = 0.1
     params.slippage_for_swap = 0.03
 
@@ -2684,12 +2686,31 @@ class TestCheckIfRouteIsProfitable:
         assert result[2] == 0.1  # total_gas_cost
 
     def test_not_profitable_fees(self):
-        """Test not profitable fees."""
+        """Fee-only excess trips the gate against the FEE limit, not the gas limit.
+
+        fee 10% sits between max_fee (5%) and max_gas (25%); gas is 0 and value loss
+        is 1% (under the 10% cap), so only the fee branch can reject. A swap to
+        ``fee_percentage > allowed_gas_percentage`` (10% > 25% -> False) would let this
+        route through — this case is the canary for that swap.
+        """
         b = _make_behaviour()
-        b._get_step_transactions_data = _make_gen_method([{"fee": 50, "gas_cost": 0}])
-        route = {"fromAmountUSD": "100", "toAmountUSD": "50", "steps": []}
+        b._get_step_transactions_data = _make_gen_method([{"fee": 10, "gas_cost": 0}])
+        route = {"fromAmountUSD": "100", "toAmountUSD": "99", "steps": []}
         result = _exhaust(b.check_if_route_is_profitable(route))
         assert result[0] is False
+
+    def test_gas_within_gas_limit_passes(self):
+        """Gas 10% (> fee limit 5%, < gas limit 25%) passes — guards the gas threshold.
+
+        Complements test_not_profitable_fees: if the gas check were swapped to
+        ``gas_percentage > allowed_fee_percentage`` (10% > 5% -> True) this route would
+        be wrongly rejected. fee is 0 and value loss is 1%, so only the gas threshold's
+        identity decides the outcome.
+        """
+        b = _make_behaviour()
+        b._get_step_transactions_data = _make_gen_method([{"fee": 0, "gas_cost": 10}])
+        route = {"fromAmountUSD": "100", "toAmountUSD": "99", "steps": []}
+        assert _exhaust(b.check_if_route_is_profitable(route))[0] is True
 
     def test_no_step_transactions(self):
         """Test no step transactions."""
@@ -2720,9 +2741,9 @@ class TestCheckIfRouteIsProfitable:
 
     def test_not_profitable_gas_only(self):
         """Gas-only excess trips the gate (guards the `or gas` branch)."""
-        b = _make_behaviour()  # max_gas_percentage = 0.05
-        b._get_step_transactions_data = _make_gen_method([{"fee": 0.5, "gas_cost": 10}])
-        # fee 0.5% passes, gas 10% > 5% -> rejected by the gas branch.
+        b = _make_behaviour()  # max_gas_percentage = 0.25
+        b._get_step_transactions_data = _make_gen_method([{"fee": 0.5, "gas_cost": 30}])
+        # fee 0.5% passes, gas 30% > 25% -> rejected by the gas branch.
         route = {"fromAmountUSD": "100", "toAmountUSD": "99", "steps": []}
         assert _exhaust(b.check_if_route_is_profitable(route))[0] is False
 

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -64,6 +64,7 @@ def _make_behaviour(**overrides: Any) -> DecisionMakingBehaviour:
     params.waiting_period_for_status_check = 0
     params.max_fee_percentage = 0.05
     params.max_gas_percentage = 0.05
+    params.max_slippage_percentage = 0.1
     params.slippage_for_swap = 0.03
 
     synced = MagicMock()
@@ -2671,7 +2672,7 @@ class TestCheckIfRouteIsProfitable:
     """TestCheckIfRouteIsProfitable."""
 
     def test_profitable(self):
-        """Test profitable."""
+        """A profitable route returns True with the total fee and gas."""
         b = _make_behaviour()
         b._get_step_transactions_data = _make_gen_method(
             [{"fee": 0.1, "gas_cost": 0.1}]
@@ -2679,13 +2680,9 @@ class TestCheckIfRouteIsProfitable:
         route = {"fromAmountUSD": "100", "toAmountUSD": "99", "steps": []}
         result = _exhaust(b.check_if_route_is_profitable(route))
         assert result[0] is True
+        assert result[1] == 0.1  # total_fee
+        assert result[2] == 0.1  # total_gas_cost
 
-    @pytest.mark.skip(
-        reason=(
-            "Profitability gate is bypassed for the Basius MVP — re-enable per "
-            "workstream 2 PR 2.6 and un-skip this test alongside that change."
-        )
-    )
     def test_not_profitable_fees(self):
         """Test not profitable fees."""
         b = _make_behaviour()
@@ -2709,6 +2706,47 @@ class TestCheckIfRouteIsProfitable:
         route = {"fromAmountUSD": "0", "toAmountUSD": "0", "steps": []}
         result = _exhaust(b.check_if_route_is_profitable(route))
         assert result[0] is False
+
+    def test_not_profitable_slippage(self):
+        """Route rejected when value-loss/slippage exceeds max_slippage_percentage."""
+        b = _make_behaviour()  # max_slippage_percentage = 0.1 (10%)
+        b._get_step_transactions_data = _make_gen_method(
+            [{"fee": 0.1, "gas_cost": 0.1}]
+        )
+        # Fees/gas pass the gate, but 20% value loss (100 -> 80) exceeds the 10% cap.
+        route = {"fromAmountUSD": "100", "toAmountUSD": "80", "steps": []}
+        result = _exhaust(b.check_if_route_is_profitable(route))
+        assert result[0] is False
+
+    def test_not_profitable_gas_only(self):
+        """Gas-only excess trips the gate (guards the `or gas` branch)."""
+        b = _make_behaviour()  # max_gas_percentage = 0.05
+        b._get_step_transactions_data = _make_gen_method([{"fee": 0.5, "gas_cost": 10}])
+        # fee 0.5% passes, gas 10% > 5% -> rejected by the gas branch.
+        route = {"fromAmountUSD": "100", "toAmountUSD": "99", "steps": []}
+        assert _exhaust(b.check_if_route_is_profitable(route))[0] is False
+
+    def test_slippage_at_cap_passes(self):
+        """Exactly the cap (10% loss) passes — guards against `>=` instead of `>`."""
+        b = _make_behaviour()  # max_slippage_percentage = 0.1
+        b._get_step_transactions_data = _make_gen_method(
+            [{"fee": 0.1, "gas_cost": 0.1}]
+        )
+        route = {
+            "fromAmountUSD": "100",
+            "toAmountUSD": "90",
+            "steps": [],
+        }  # exactly 10%
+        assert _exhaust(b.check_if_route_is_profitable(route))[0] is True
+
+    def test_value_gaining_route_passes(self):
+        """A value-gaining route (toAmountUSD > fromAmountUSD) has negative loss, passes."""
+        b = _make_behaviour()
+        b._get_step_transactions_data = _make_gen_method(
+            [{"fee": 0.1, "gas_cost": 0.1}]
+        )
+        route = {"fromAmountUSD": "100", "toAmountUSD": "101", "steps": []}
+        assert _exhaust(b.check_if_route_is_profitable(route))[0] is True
 
 
 class TestCheckStepCosts:

--- a/packages/valory/skills/liquidity_trader_abci/tests/test_models.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/test_models.py
@@ -588,6 +588,7 @@ class TestParams:
             "min_investment_amount": 100,
             "max_fee_percentage": 0.1,
             "max_gas_percentage": 0.05,
+            "max_slippage_percentage": 0.1,
             "balancer_graphql_endpoints": json.dumps({}),
             "target_investment_chains": ["ethereum"],
             "staking_chain": "ethereum",

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -126,7 +126,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeic6n6nazlkvdutgglhnrjfjt7lyenm2gad3xqljgjs2kafvszwsea
+- valory/liquidity_trader_abci:0.1.0:bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 behaviours:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -126,7 +126,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeigihakkoadujfs7yyc3lexasnyyyy33fbvhzuz7msdsbm5fmaptta
+- valory/liquidity_trader_abci:0.1.0:bafybeidv4pgnz53vsafcianlm6wzxe3bl26ohfiasgkw4hsm57ap6qoaxq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 behaviours:


### PR DESCRIPTION
**Stacked on #332 (PR2).** Base = `feat/ws2-opportunity-cache`.

## WS2 Tasks 2.6 + 2.5 — re-enable safety checks

### 2.6 — Profitability gate
Re-enables the fee/gas gate in `check_if_route_is_profitable` (`decision_making.py`) that was commented out for the Basius MVP. Routes whose fee% or gas% exceed `max_fee_percentage` / `max_gas_percentage` are rejected again. **This also fixes the pre-existing `test_not_profitable_fees` failure** that was red on the branch (and inherited by PR1/PR2).

### 2.5 — Slippage protection (config restore + swap cap)
- **Config restore:** `service.yaml` `slippage_tolerance` default `1.0 → 0.01` (still `${SLIPPAGE_TOLERANCE:...}`-overridable). `1.0` = 100% made LP add/remove min-amounts ≈ 0, i.e. protection off. The final production value is calibrated in **WS3 3.5**.
- **Swap-level cap:** new `max_slippage_percentage` param + an agent-side value-loss reject in `check_if_route_is_profitable` using `(fromAmountUSD − toAmountUSD)/fromAmountUSD`, independent of LiFi's own slippage handling. Wired through `models.py`, `skill.yaml`, `aea-config.yaml`, `service.yaml` (default `0.1`, env `MAX_SLIPPAGE_PERCENTAGE`).

### Tests
- `_make_behaviour` sets the new param; added `test_not_profitable_slippage` (passes fee/gas gate, exceeds the value-loss cap → rejected); `test_models` config updated. `decision_making.py` at **100% coverage**; full skill suite green except one **pre-existing, unrelated** failure (`test_velodrome.py::…::test_query_returns_none` — the WS3-3.3 disabled Aerodrome check, also red on the base branch).

### Notes
- The slippage cap default (`0.1`) and `slippage_tolerance` (`0.01`) are interim/protective; **WS3 3.4/3.5** calibrate the production values for thin Base stables.

WS2 stack: PR1 (#331) → PR2 (#332) → **PR3 (this, 2.5 + 2.6)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
