### PR TITLE
feat(whitelist): restrict Optimism and Base whitelists to approved stablecoins

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,10 +22,10 @@
         "contract/valory/velodrome_voter/0.1.0": "bafybeieawpdivhzrbjk6ivsrncxah5y5gbb32qxmrcb2dxmw55ev7gowda",
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe",
-        "skill/valory/optimus_abci/0.1.0": "bafybeiegv5xxubemdysav4vobjbkzftoqbihpq7azigaoz5hjo4p55knte",
-        "agent/valory/optimus/0.1.0": "bafybeifccrjka4mwjl6rmsst74ha7n7bogixpl7rhjk6rocfinnd5a4a6q",
-        "service/valory/optimus/0.1.0": "bafybeifdfg5vvjdhk6h6nwpwqslmyzkehugziz5ra4nyt6c7ultmerjw5i"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiae37alcshztwsj5ska6cxpuxwi4a7pb3jzuvhznyvlwci5gmboku",
+        "agent/valory/optimus/0.1.0": "bafybeihpugxvwzovvgu6tzhujv5z4ovt57qfl26xpcrgboud3olmqjc37e",
+        "service/valory/optimus/0.1.0": "bafybeie5t2xselswyehtpclb4m4effka5o4p7hn5foobyxyvidurvx4ufm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,10 +22,10 @@
         "contract/valory/velodrome_voter/0.1.0": "bafybeieawpdivhzrbjk6ivsrncxah5y5gbb32qxmrcb2dxmw55ev7gowda",
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeifojiolxc5dz6kmtzf7o73rzfzzoeufvo5mrxedtmg2zjlxx3uqqq",
-        "skill/valory/optimus_abci/0.1.0": "bafybeidhk5reml6vqhh5hkdbgisqfob4v63dkvdrcgqjol54bzpcbzg4py",
-        "agent/valory/optimus/0.1.0": "bafybeiadles7napatcvomxencwd2eikg6wrdvk6oyn22gc7mwjunpnndoa",
-        "service/valory/optimus/0.1.0": "bafybeiecj4cch457yypnk4feqtucnz2klhmftv74k67fqdqiognk3ps3y4"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiegv5xxubemdysav4vobjbkzftoqbihpq7azigaoz5hjo4p55knte",
+        "agent/valory/optimus/0.1.0": "bafybeifccrjka4mwjl6rmsst74ha7n7bogixpl7rhjk6rocfinnd5a4a6q",
+        "service/valory/optimus/0.1.0": "bafybeifdfg5vvjdhk6h6nwpwqslmyzkehugziz5ra4nyt6c7ultmerjw5i"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,10 +22,10 @@
         "contract/valory/velodrome_voter/0.1.0": "bafybeieawpdivhzrbjk6ivsrncxah5y5gbb32qxmrcb2dxmw55ev7gowda",
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq",
-        "skill/valory/optimus_abci/0.1.0": "bafybeiae37alcshztwsj5ska6cxpuxwi4a7pb3jzuvhznyvlwci5gmboku",
-        "agent/valory/optimus/0.1.0": "bafybeihpugxvwzovvgu6tzhujv5z4ovt57qfl26xpcrgboud3olmqjc37e",
-        "service/valory/optimus/0.1.0": "bafybeie5t2xselswyehtpclb4m4effka5o4p7hn5foobyxyvidurvx4ufm"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeia32dcuuxcytm7v63enlfjpltxcduaxktr7mhe22idap262xbjmjy",
+        "skill/valory/optimus_abci/0.1.0": "bafybeifx5h3wvfjwa6mz7c24st3cg3ldk3s2oq27pin2rdt2hpk7myq35e",
+        "agent/valory/optimus/0.1.0": "bafybeihm62pfpn75u6bdrjeruiq6sboafbd772pihtiuargnrjviul3kle",
+        "service/valory/optimus/0.1.0": "bafybeigwhmxzzsf3ztwb4iyy4rj64rsavmjf73te6elhcm45tnthby7dea"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -51,8 +51,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe
-- valory/optimus_abci:0.1.0:bafybeiegv5xxubemdysav4vobjbkzftoqbihpq7azigaoz5hjo4p55knte
+- valory/liquidity_trader_abci:0.1.0:bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq
+- valory/optimus_abci:0.1.0:bafybeiae37alcshztwsj5ska6cxpuxwi4a7pb3jzuvhznyvlwci5gmboku
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -51,8 +51,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq
-- valory/optimus_abci:0.1.0:bafybeiae37alcshztwsj5ska6cxpuxwi4a7pb3jzuvhznyvlwci5gmboku
+- valory/liquidity_trader_abci:0.1.0:bafybeia32dcuuxcytm7v63enlfjpltxcduaxktr7mhe22idap262xbjmjy
+- valory/optimus_abci:0.1.0:bafybeifx5h3wvfjwa6mz7c24st3cg3ldk3s2oq27pin2rdt2hpk7myq35e
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -51,8 +51,8 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeifojiolxc5dz6kmtzf7o73rzfzzoeufvo5mrxedtmg2zjlxx3uqqq
-- valory/optimus_abci:0.1.0:bafybeidhk5reml6vqhh5hkdbgisqfob4v63dkvdrcgqjol54bzpcbzg4py
+- valory/liquidity_trader_abci:0.1.0:bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe
+- valory/optimus_abci:0.1.0:bafybeiegv5xxubemdysav4vobjbkzftoqbihpq7azigaoz5hjo4p55knte
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeiadles7napatcvomxencwd2eikg6wrdvk6oyn22gc7mwjunpnndoa
+agent: valory/optimus:0.1.0:bafybeifccrjka4mwjl6rmsst74ha7n7bogixpl7rhjk6rocfinnd5a4a6q
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeifccrjka4mwjl6rmsst74ha7n7bogixpl7rhjk6rocfinnd5a4a6q
+agent: valory/optimus:0.1.0:bafybeihpugxvwzovvgu6tzhujv5z4ovt57qfl26xpcrgboud3olmqjc37e
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeihpugxvwzovvgu6tzhujv5z4ovt57qfl26xpcrgboud3olmqjc37e
+agent: valory/optimus:0.1.0:bafybeihm62pfpn75u6bdrjeruiq6sboafbd772pihtiuargnrjviul3kle
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -280,7 +280,11 @@ POOL_FILENAME = "current_pool.json"
 READ_MODE = "r"
 WRITE_MODE = "w"
 
-# Whitelist of allowed token addresses for each chain with their symbols
+# Investable whitelist: token addresses (with symbols) the agent is allowed to
+# ENTER new positions with, per chain. This is the gate consumed by the
+# strategy / investability path (evaluate_strategy). To stop investing in an
+# asset, remove it here -- but if existing agents may still HOLD it, also add it
+# to LEGACY_HELD_ASSETS below so it stays detectable, convertible and priceable.
 WHITELISTED_ASSETS = {
     "mode": {
         # MODE tokens - stablecoins
@@ -316,6 +320,30 @@ WHITELISTED_ASSETS = {
         "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4": "eUSD",
         "0xeb466342c4d449bc9f53a865d5cb90586f405215": "axlUSDC",
     },
+}
+
+# Assets that are no longer investable (intentionally absent from
+# WHITELISTED_ASSETS) but may still sit in an existing agent's Safe. They are
+# excluded from new investment yet must remain (a) detectable by the on-chain
+# balance backstop and last-known-balance tracker, (b) convertible by the
+# withdraw sweep-to-USDC fallback, and (c) priceable via COIN_ID_MAPPING. Drop
+# an entry here once on-chain balances for it have reached zero.
+LEGACY_HELD_ASSETS: Dict[str, Dict[str, str]] = {
+    # oUSDT was removed from the Optimism investable whitelist, but existing
+    # optimus agents may still hold it.
+    "optimism": {
+        "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189": "oUSDT",
+    },
+}
+
+# Detection / sweep set: every investable asset PLUS any legacy held asset for
+# the chain. Consumed by the on-chain balance backstop
+# (_supplement_with_onchain_whitelisted_balances), the last-known-balance
+# tracker, and the withdraw sweep-to-USDC fallback. Always a superset of
+# WHITELISTED_ASSETS.
+HELD_ASSETS: Dict[str, Dict[str, str]] = {
+    chain: {**assets, **LEGACY_HELD_ASSETS.get(chain, {})}
+    for chain, assets in WHITELISTED_ASSETS.items()
 }
 
 COIN_ID_MAPPING = {
@@ -587,7 +615,7 @@ class LiquidityTraderBaseBehaviour(
         if native_balance is not None:
             current[ZERO_ADDRESS.lower()] = int(native_balance)
 
-        for token_addr, _symbol in WHITELISTED_ASSETS.get(chain, {}).items():
+        for token_addr, _symbol in HELD_ASSETS.get(chain, {}).items():
             token_balance = yield from self._get_token_balance(
                 chain, safe_address, token_addr
             )
@@ -859,11 +887,12 @@ class LiquidityTraderBaseBehaviour(
                         }
                     )
 
-        # On-chain backstop for whitelisted ERC20s and native ETH. Catches the
-        # case where SafeApi is unavailable (e.g. monthly quota exceeded) or
-        # returns an incomplete trusted-token list. Covers every entry in
-        # WHITELISTED_ASSETS[chain]. Reward tokens (OLAS, VELO) are disjoint
-        # from the whitelist and handled by _fetch_reward_balances below.
+        # On-chain backstop for held ERC20s and native ETH. Catches the case
+        # where SafeApi is unavailable (e.g. monthly quota exceeded) or returns
+        # an incomplete trusted-token list. Covers every entry in
+        # HELD_ASSETS[chain] (the investable whitelist plus legacy held assets),
+        # so already-held but de-whitelisted tokens stay visible. Reward tokens
+        # (OLAS, VELO) are disjoint and handled by _fetch_reward_balances below.
         yield from self._supplement_with_onchain_whitelisted_balances(
             chain, safe_address, balances
         )
@@ -3402,9 +3431,9 @@ class LiquidityTraderBaseBehaviour(
         safe_address: str,
         balances: List[Dict[str, Any]],
     ) -> Generator[None, None, None]:
-        """Add on-chain balances for whitelisted assets not present in ``balances``.
+        """Add on-chain balances for held assets not present in ``balances``.
 
-        Mutates ``balances`` in place. For each entry in ``WHITELISTED_ASSETS[chain]``
+        Mutates ``balances`` in place. For each entry in ``HELD_ASSETS[chain]``
         plus native ETH, appends an entry sourced from on-chain reads when:
         - the address is not already in ``balances`` (case-insensitive match), and
         - the on-chain balance is strictly positive.
@@ -3448,7 +3477,7 @@ class LiquidityTraderBaseBehaviour(
                     f"Error reading native balance on {chain}: {str(e)}"
                 )
 
-        for whitelisted_addr, symbol in WHITELISTED_ASSETS.get(chain, {}).items():
+        for whitelisted_addr, symbol in HELD_ASSETS.get(chain, {}).items():
             key = whitelisted_addr.lower()
             if key in already_have:
                 continue

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -302,32 +302,19 @@ WHITELISTED_ASSETS = {
     "optimism": {
         # Optimism tokens - stablecoins
         "0x0b2c639c533813f4aa9d7837caf62653d097ff85": "USDC",
-        "0x01bff41798a0bcf287b996046ca68b395dbc1071": "USDT0",
-        "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58": "USDT",
-        "0x7f5c764cbc14f9669b88837ca1490cca17c31607": "USDC.e",
         "0x2218a117083f5b482b0bb821d27056ba9c04b1d3": "sDAI",
-        "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189": "oUSDT",
+        "0x01bff41798a0bcf287b996046ca68b395dbc1071": "USDT0",
+        "0x7f5c764cbc14f9669b88837ca1490cca17c31607": "USDC.e",
+        "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58": "USDT",
     },
     "base": {
         # Base tokens - stablecoins
         "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": "USDC",
-        "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189": "oUSDT",
-        "0xeb466342c4d449bc9f53a865d5cb90586f405215": "axlUSDC",
+        "0x03569cc076654f82679c4ba2124d64774781b01d": "BOLD",
         "0x526728dbc96689597f85ae4cd716d4f7fccbae9d": "msUSD",
         "0xe5020a6d073a794b6e7f05678707de47986fb0b6": "frxUSD",
-        # Tier-1 stablecoin additions from the Base/Aerodrome LpSugar whitelist
-        # sweep: each is $1-pegged, has a CoinGecko coin id for pricing, and pairs
-        # with a whitelisted anchor (USDC; eUSD also pairs frxUSD). A pool is only
-        # investable when every token in it is whitelisted, so each unlocks real
-        # Aerodrome depth. Ordered by safety x liquidity.
-        "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2": "USDT",
-        "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34": "USDe",
         "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4": "eUSD",
-        "0x4621b7a9c75199271f773ebd9a499dbd165c3191": "DOLA",
-        "0xdd468a1ddc392dcdbef6db6e34e89aa338f9f186": "MUSD",
-        "0x35e5db674d8e93a03d814fa0ada70731efe8a4b9": "USR",
-        "0x04d5ddf5f3a8939889f11e97f8c4bb48317f1938": "USDz",
-        "0x03569cc076654f82679c4ba2124d64774781b01d": "BOLD",
+        "0xeb466342c4d449bc9f53a865d5cb90586f405215": "axlUSDC",
     },
 }
 
@@ -875,9 +862,8 @@ class LiquidityTraderBaseBehaviour(
         # On-chain backstop for whitelisted ERC20s and native ETH. Catches the
         # case where SafeApi is unavailable (e.g. monthly quota exceeded) or
         # returns an incomplete trusted-token list. Covers every entry in
-        # WHITELISTED_ASSETS[chain] including oUSDT, which used to be fetched
-        # separately. Reward tokens (OLAS, VELO) are disjoint from the
-        # whitelist and handled by _fetch_reward_balances below.
+        # WHITELISTED_ASSETS[chain]. Reward tokens (OLAS, VELO) are disjoint
+        # from the whitelist and handled by _fetch_reward_balances below.
         yield from self._supplement_with_onchain_whitelisted_balances(
             chain, safe_address, balances
         )

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/withdraw_funds.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/withdraw_funds.py
@@ -25,9 +25,9 @@ from typing import Any, Dict, Generator, List, Optional, Set
 
 from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
     Action,
+    HELD_ASSETS,
     LiquidityTraderBaseBehaviour,
     PositionStatus,
-    WHITELISTED_ASSETS,
 )
 from packages.valory.skills.liquidity_trader_abci.payloads import WithdrawFundsPayload
 from packages.valory.skills.liquidity_trader_abci.states.withdraw_funds import (
@@ -419,7 +419,9 @@ class WithdrawFundsBehaviour(LiquidityTraderBaseBehaviour):
             tokens_to_swap[token_address] = asset.get("asset") or ""
 
         if safe_address:
-            for whitelisted_addr, symbol in WHITELISTED_ASSETS.get(chain, {}).items():
+            # Sweep the held/detection set (HELD_ASSETS), not just the investable
+            # whitelist, so already-held but de-whitelisted tokens still convert.
+            for whitelisted_addr, symbol in HELD_ASSETS.get(chain, {}).items():
                 key = whitelisted_addr.lower()
                 if key in (usdc_lc, olas_lc) or key in seen:
                     continue

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
-  behaviours/base.py: bafybeib2n6i3p4fw6csolh5tmwt6dwycsvt5jssywhg6p4qsllt7q74hzi
+  behaviours/base.py: bafybeia6bujoda63k6nwjjpfslicaopjjg2nrlkakhuawec2qdzoflowem
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeihyopur3kvipshjfclzzmoz6xrdfohss5bra2aoku6a5tmlu4cqqm
   behaviours/decision_making.py: bafybeiecevpplgg23gptaexr6kp4opddeydms5lzziuehtngdxxc3mayw4
@@ -17,7 +17,7 @@ fingerprint:
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
   behaviours/post_tx_settlement.py: bafybeia2fn7abt7zjifitv34vwylohqmuk5r7ptkdk62oeemg66v3klfii
   behaviours/round_behaviour.py: bafybeiafqu4chrxrtxqijd22h6xim4sbon5j4rz3any3vfpbi3qhsovyua
-  behaviours/withdraw_funds.py: bafybeidezb4cwhjcj5yjphg5jmzblikkfsbwk32xjv66la3aozch3zfnry
+  behaviours/withdraw_funds.py: bafybeiaekrve5ozaogcu6ufqcnkqgkapdtjrlknif3nswhu5xkl6r5eaxm
   dialogues.py: bafybeic5bdlovivzkv3jnj6khbs7tzukv64ucea7w7y3tn2tgsequb2u2i
   fsm_specification.yaml: bafybeib2tuhdbygebur4i3vymsarxasxlmuumjfzbxzn2kua5ltl55zjra
   handlers.py: bafybeigxkxtlzq53eedt3ig27gmyarv7gd63p2dgzi3oqdnyuyjhiffzqi
@@ -46,7 +46,7 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeidkwwma4ojcp4osr7ayfeodjnkikriz6krzczgtcfzx6mqj55kyvy
+  tests/behaviours/test_base.py: bafybeidju6ma4wx2arnpswzu5liq45ttt2e3j7rnp2pqhr3kptigt7tj6u
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeiexrnygyxckf4b2sa37caqsw7ceyuelqqueapg24hc35aodiv66xq
   tests/behaviours/test_decision_making.py: bafybeigs63ccyv6nivol2p4nqxvhfn6obkukib2kgaa5hzrhtje564ziuu
@@ -55,7 +55,7 @@ fingerprint:
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu
   tests/behaviours/test_post_tx_settlement.py: bafybeigievecybq7geucnqou7av3rrqsnjitgxydbo6fjopmki34n74q5u
   tests/behaviours/test_round_behaviour.py: bafybeibwy6np27mile6hf72nfjh65qsvegzedmsyeskfeprdwfvjbe77jq
-  tests/behaviours/test_withdraw_funds.py: bafybeihhvrlp4o4pbpywejbv6ifzjycii7r7dce2ki77atpuk23gdso7gu
+  tests/behaviours/test_withdraw_funds.py: bafybeiffeqkzce72lwgfl2dwf56mbqwtu52qafa7sfuaozf3iwodcpnr5u
   tests/io_/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/io_/test_loader.py: bafybeiclt5hynt4u2djnnjs6rzdns5jb7c4nkf7nywtyvniy5oagftyh3a
   tests/pools/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -46,7 +46,7 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeidju6ma4wx2arnpswzu5liq45ttt2e3j7rnp2pqhr3kptigt7tj6u
+  tests/behaviours/test_base.py: bafybeiat5mag53euvpnghihbhxunrbdzqpxrz633vrr7drjnupoxywmqci
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeiexrnygyxckf4b2sa37caqsw7ceyuelqqueapg24hc35aodiv66xq
   tests/behaviours/test_decision_making.py: bafybeigs63ccyv6nivol2p4nqxvhfn6obkukib2kgaa5hzrhtje564ziuu

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -8,7 +8,7 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
-  behaviours/base.py: bafybeiardzexfplwukizdmiev3wfavaquyi6o6mpxqzmz7kuo3wdqvuxfi
+  behaviours/base.py: bafybeib2n6i3p4fw6csolh5tmwt6dwycsvt5jssywhg6p4qsllt7q74hzi
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeihyopur3kvipshjfclzzmoz6xrdfohss5bra2aoku6a5tmlu4cqqm
   behaviours/decision_making.py: bafybeiecevpplgg23gptaexr6kp4opddeydms5lzziuehtngdxxc3mayw4
@@ -46,7 +46,7 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeid7pqe7hv7xcsp2tyw5mtwnl3vev5t466fe46oo4jud6tiwcpr2ha
+  tests/behaviours/test_base.py: bafybeidkwwma4ojcp4osr7ayfeodjnkikriz6krzczgtcfzx6mqj55kyvy
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeiexrnygyxckf4b2sa37caqsw7ceyuelqqueapg24hc35aodiv66xq
   tests/behaviours/test_decision_making.py: bafybeigs63ccyv6nivol2p4nqxvhfn6obkukib2kgaa5hzrhtje564ziuu
@@ -55,7 +55,7 @@ fingerprint:
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu
   tests/behaviours/test_post_tx_settlement.py: bafybeigievecybq7geucnqou7av3rrqsnjitgxydbo6fjopmki34n74q5u
   tests/behaviours/test_round_behaviour.py: bafybeibwy6np27mile6hf72nfjh65qsvegzedmsyeskfeprdwfvjbe77jq
-  tests/behaviours/test_withdraw_funds.py: bafybeiewpa4nvaimll5uc3vgazr2gaz4uuvbij3zaplelwyxv3y3mfhmwa
+  tests/behaviours/test_withdraw_funds.py: bafybeihhvrlp4o4pbpywejbv6ifzjycii7r7dce2ki77atpuk23gdso7gu
   tests/io_/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/io_/test_loader.py: bafybeiclt5hynt4u2djnnjs6rzdns5jb7c4nkf7nywtyvniy5oagftyh3a
   tests/pools/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -1912,11 +1912,11 @@ class TestWhitelistInvariants:
         assert {a.lower() for a in WHITELISTED_ASSETS["base"]} == self.BASE_INVESTABLE
 
     def test_ousdt_is_not_investable_on_optimism(self) -> None:
-        """oUSDT is excluded from the investable whitelist (no new investment)."""
+        """Legacy oUSDT is excluded from the investable whitelist (no new investment)."""
         assert self.OUSDT not in {a.lower() for a in WHITELISTED_ASSETS["optimism"]}
 
     def test_ousdt_remains_in_optimism_held_set(self) -> None:
-        """oUSDT stays in the held/sweep set so existing holdings convert."""
+        """Legacy oUSDT stays in the held/sweep set so existing holdings convert."""
         assert self.OUSDT in {a.lower() for a in HELD_ASSETS["optimism"]}
         assert self.OUSDT in LEGACY_HELD_ASSETS["optimism"]
 

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -1630,7 +1630,7 @@ class TestGetSafeBalancesFromSafeApi:
         """End-to-end backstop integration when SafeApi returns partial data.
 
         SafeApi returns only ETH; the real backstop adds the whitelisted
-        ERC20s (including oUSDT) on top, without duplicating ETH.
+        ERC20s (including sDAI) on top, without duplicating ETH.
 
         This guards the ordering and dedup contract between
         ``_get_safe_balances_from_safe_api`` and the live
@@ -1648,31 +1648,31 @@ class TestGetSafeBalancesFromSafeApi:
         )
         # Backstop runs for real. Stub RPC reads so on-chain says:
         # native ETH 999 (won't be added — ETH already came from SafeApi)
-        # oUSDT 5_000_000 (will be added by backstop)
+        # sDAI 5_000_000 (will be added by backstop)
         # everything else: 0
-        OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        SDAI = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
         b._get_native_balance = _make_gen(999)  # type: ignore[assignment,method-assign]
 
         def fake_token_balance(chain: Any, account: Any, address: Any) -> Any:
             yield
-            return 5_000_000 if (address or "").lower() == OUSDT else 0
+            return 5_000_000 if (address or "").lower() == SDAI else 0
 
         b._get_token_balance = fake_token_balance  # type: ignore[assignment,method-assign]
 
         result = _exhaust(b._get_safe_balances_from_safe_api("optimism"))
         symbols = [r["asset_symbol"] for r in result]
         eth_entries = [r for r in result if r["asset_symbol"] == "ETH"]
-        ousdt_entries = [r for r in result if r["asset_symbol"] == "oUSDT"]
+        sdai_entries = [r for r in result if r["asset_symbol"] == "sDAI"]
         # ETH from SafeApi is preserved; backstop did not duplicate it.
         assert len(eth_entries) == 1
         assert (
             eth_entries[0]["balance"] == 1_000_000_000_000_000
         )  # SafeApi value, not 999
-        # oUSDT picked up by the backstop.
-        assert len(ousdt_entries) == 1
-        assert ousdt_entries[0]["balance"] == 5_000_000
+        # sDAI picked up by the backstop.
+        assert len(sdai_entries) == 1
+        assert sdai_entries[0]["balance"] == 5_000_000
         # No other whitelisted token was added (all returned 0 on-chain).
-        assert sorted(symbols) == ["ETH", "oUSDT"]
+        assert sorted(symbols) == ["ETH", "sDAI"]
 
 
 class TestSupplementWithOnchainWhitelistedBalances:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -33,6 +33,8 @@ from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
     Action,
     ETH_REMAINING_KEY,
     GasCostTracker,
+    HELD_ASSETS,
+    LEGACY_HELD_ASSETS,
     LiquidityTraderBaseBehaviour,
     MIN_TIME_IN_POSITION,
     OLAS_ADDRESSES,
@@ -1629,8 +1631,9 @@ class TestGetSafeBalancesFromSafeApi:
     def test_backstop_integrates_when_safeapi_partial(self) -> None:
         """End-to-end backstop integration when SafeApi returns partial data.
 
-        SafeApi returns only ETH; the real backstop adds the whitelisted
-        ERC20s (including sDAI) on top, without duplicating ETH.
+        SafeApi returns only ETH; the real backstop adds the held ERC20s
+        (including legacy-held oUSDT, de-whitelisted but still in HELD_ASSETS)
+        on top, without duplicating ETH.
 
         This guards the ordering and dedup contract between
         ``_get_safe_balances_from_safe_api`` and the live
@@ -1648,31 +1651,31 @@ class TestGetSafeBalancesFromSafeApi:
         )
         # Backstop runs for real. Stub RPC reads so on-chain says:
         # native ETH 999 (won't be added — ETH already came from SafeApi)
-        # sDAI 5_000_000 (will be added by backstop)
+        # oUSDT 5_000_000 (will be added by backstop)
         # everything else: 0
-        SDAI = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
         b._get_native_balance = _make_gen(999)  # type: ignore[assignment,method-assign]
 
         def fake_token_balance(chain: Any, account: Any, address: Any) -> Any:
             yield
-            return 5_000_000 if (address or "").lower() == SDAI else 0
+            return 5_000_000 if (address or "").lower() == OUSDT else 0
 
         b._get_token_balance = fake_token_balance  # type: ignore[assignment,method-assign]
 
         result = _exhaust(b._get_safe_balances_from_safe_api("optimism"))
         symbols = [r["asset_symbol"] for r in result]
         eth_entries = [r for r in result if r["asset_symbol"] == "ETH"]
-        sdai_entries = [r for r in result if r["asset_symbol"] == "sDAI"]
+        ousdt_entries = [r for r in result if r["asset_symbol"] == "oUSDT"]
         # ETH from SafeApi is preserved; backstop did not duplicate it.
         assert len(eth_entries) == 1
         assert (
             eth_entries[0]["balance"] == 1_000_000_000_000_000
         )  # SafeApi value, not 999
-        # sDAI picked up by the backstop.
-        assert len(sdai_entries) == 1
-        assert sdai_entries[0]["balance"] == 5_000_000
-        # No other whitelisted token was added (all returned 0 on-chain).
-        assert sorted(symbols) == ["ETH", "sDAI"]
+        # Legacy-held oUSDT picked up by the backstop via HELD_ASSETS.
+        assert len(ousdt_entries) == 1
+        assert ousdt_entries[0]["balance"] == 5_000_000
+        # No other held token was added (all returned 0 on-chain).
+        assert sorted(symbols) == ["ETH", "oUSDT"]
 
 
 class TestSupplementWithOnchainWhitelistedBalances:
@@ -1725,9 +1728,7 @@ class TestSupplementWithOnchainWhitelistedBalances:
         # Per-address fake pins the symbol-to-address mapping: a mismatch in the
         # loop (wrong key, short-circuit, swapped symbol) would surface as a
         # missing/incorrect balance in the asserted dict.
-        expected = {
-            addr: i + 1 for i, addr in enumerate(WHITELISTED_ASSETS["optimism"])
-        }
+        expected = {addr: i + 1 for i, addr in enumerate(HELD_ASSETS["optimism"])}
 
         def fake_token_balance(
             chain: str, account: str, address: str
@@ -1746,9 +1747,9 @@ class TestSupplementWithOnchainWhitelistedBalances:
         # Pin: every whitelisted entry must be present with the exact balance
         # produced by the per-address fake (catches loop short-circuit and
         # symbol/address mapping swaps).
-        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
+        assert len(balances) == len(HELD_ASSETS["optimism"])
         balance_by_address = {entry["address"].lower(): entry for entry in balances}
-        for address, symbol in WHITELISTED_ASSETS["optimism"].items():
+        for address, symbol in HELD_ASSETS["optimism"].items():
             entry = balance_by_address[address.lower()]
             assert entry["asset_symbol"] == symbol
             assert entry["asset_type"] == "erc_20"
@@ -1813,7 +1814,7 @@ class TestSupplementWithOnchainWhitelistedBalances:
         """
         b = _make_behaviour()
         b._get_native_balance = _make_gen(0)  # type: ignore[assignment,method-assign]
-        addresses = list(WHITELISTED_ASSETS["optimism"].keys())
+        addresses = list(HELD_ASSETS["optimism"].keys())
         failing_address = addresses[0]
 
         def flaky_token_balance(
@@ -1857,7 +1858,7 @@ class TestSupplementWithOnchainWhitelistedBalances:
         )
         # No ETH entry, but every whitelisted ERC20 made it.
         assert not any(entry["asset_symbol"] == "ETH" for entry in balances)
-        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
+        assert len(balances) == len(HELD_ASSETS["optimism"])
 
     def test_native_none_does_not_block_erc20s(self) -> None:
         """A native None read is logged and skipped; ERC20 backstop still runs."""
@@ -1871,7 +1872,59 @@ class TestSupplementWithOnchainWhitelistedBalances:
             )
         )
         assert not any(entry["asset_symbol"] == "ETH" for entry in balances)
-        assert len(balances) == len(WHITELISTED_ASSETS["optimism"])
+        assert len(balances) == len(HELD_ASSETS["optimism"])
+
+
+class TestWhitelistInvariants:
+    """Pin the curated investable whitelist and the held/sweep superset.
+
+    The behavioural tests iterate these dicts dynamically, so they adapt to any
+    contents and would not catch a mistyped address or an accidental re-add.
+    These assertions pin the exact membership and the investable-vs-held split.
+    """
+
+    # Lowercased; symbols in comments for reviewer legibility.
+    OPTIMISM_INVESTABLE = {
+        "0x0b2c639c533813f4aa9d7837caf62653d097ff85",  # USDC (native)
+        "0x2218a117083f5b482b0bb821d27056ba9c04b1d3",  # sDAI
+        "0x01bff41798a0bcf287b996046ca68b395dbc1071",  # USDT0
+        "0x7f5c764cbc14f9669b88837ca1490cca17c31607",  # USDC.e
+        "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",  # USDT (bridged)
+    }
+    BASE_INVESTABLE = {
+        "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",  # USDC (native)
+        "0x03569cc076654f82679c4ba2124d64774781b01d",  # BOLD
+        "0x526728dbc96689597f85ae4cd716d4f7fccbae9d",  # msUSD
+        "0xe5020a6d073a794b6e7f05678707de47986fb0b6",  # frxUSD
+        "0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4",  # eUSD
+        "0xeb466342c4d449bc9f53a865d5cb90586f405215",  # axlUSDC
+    }
+    OUSDT = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+
+    def test_optimism_investable_set_is_exact(self) -> None:
+        """Optimism investable whitelist is exactly the curated five."""
+        assert {a.lower() for a in WHITELISTED_ASSETS["optimism"]} == (
+            self.OPTIMISM_INVESTABLE
+        )
+
+    def test_base_investable_set_is_exact(self) -> None:
+        """Base investable whitelist is exactly the curated six."""
+        assert {a.lower() for a in WHITELISTED_ASSETS["base"]} == self.BASE_INVESTABLE
+
+    def test_ousdt_is_not_investable_on_optimism(self) -> None:
+        """oUSDT is excluded from the investable whitelist (no new investment)."""
+        assert self.OUSDT not in {a.lower() for a in WHITELISTED_ASSETS["optimism"]}
+
+    def test_ousdt_remains_in_optimism_held_set(self) -> None:
+        """oUSDT stays in the held/sweep set so existing holdings convert."""
+        assert self.OUSDT in {a.lower() for a in HELD_ASSETS["optimism"]}
+        assert self.OUSDT in LEGACY_HELD_ASSETS["optimism"]
+
+    def test_held_assets_is_superset_of_investable(self) -> None:
+        """HELD_ASSETS is always a superset of the investable whitelist."""
+        for chain, investable in WHITELISTED_ASSETS.items():
+            held = {a.lower() for a in HELD_ASSETS[chain]}
+            assert {a.lower() for a in investable}.issubset(held)
 
 
 class TestGetModeBalances:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_withdraw_funds.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_withdraw_funds.py
@@ -684,18 +684,19 @@ class TestPrepareSwapToUsdcActionsStandard:
         assert len(result) == 1
 
     def test_safe_held_backstop_picks_up_idle_token(self) -> None:
-        """Empty portfolio_breakdown but safe holds a whitelisted token: queue the swap."""
-        # Real WHITELISTED_ASSETS["optimism"] entry: sDAI.
-        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
-        obj = self._make_obj(balances={sdai: 5_000_000})
+        """Empty portfolio_breakdown but safe holds a token in HELD_ASSETS: queue the swap."""
+        # Legacy-held HELD_ASSETS["optimism"] entry: oUSDT (de-whitelisted but
+        # still swept so existing holdings convert).
+        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        obj = self._make_obj(balances={ousdt: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {"portfolio_breakdown": []}
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))
         assert len(result) == 1
-        # Verify the swap was built for sDAI, not for some unrelated token.
+        # Verify the swap was built for oUSDT, not for some unrelated token.
         kwargs = obj._build_swap_to_usdc_action.call_args.kwargs
-        assert kwargs["from_token_address"].lower() == sdai
+        assert kwargs["from_token_address"].lower() == ousdt
 
     def test_safe_held_backstop_skips_zero_balance_tokens(self) -> None:
         """Whitelisted tokens with zero balance must not be queued."""
@@ -710,13 +711,13 @@ class TestPrepareSwapToUsdcActionsStandard:
     def test_safe_held_backstop_dedupes_against_portfolio(self) -> None:
         """A token already queued from portfolio_breakdown is not re-queued from the # noqa: D205,D209
         on-chain backstop."""
-        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
-        obj = self._make_obj(balances={sdai: 5_000_000})
+        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        obj = self._make_obj(balances={ousdt: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {
             "portfolio_breakdown": [
-                {"asset": "sDAI", "address": sdai, "value_usd": 50},
+                {"asset": "oUSDT", "address": ousdt, "value_usd": 50},
             ]
         }
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))
@@ -752,8 +753,8 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_skips_dust_below_one_token_unit(self) -> None:
         """Balance below one whole token unit is skipped as dust."""
-        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
-        obj = self._make_obj(balances={sdai: 999_999}, decimals=6)
+        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        obj = self._make_obj(balances={ousdt: 999_999}, decimals=6)
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {"portfolio_breakdown": []}
@@ -763,8 +764,8 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_skips_when_decimals_unavailable(self) -> None:
         """Token is skipped when _get_token_decimals returns None."""
-        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
-        obj = self._make_obj(balances={sdai: 5_000_000})
+        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        obj = self._make_obj(balances={ousdt: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         def fake_decimals_none(chain, asset_address):
@@ -779,15 +780,15 @@ class TestPrepareSwapToUsdcActionsStandard:
         assert len(result) == 0
 
     def test_safe_held_backstop_dedupes_mixed_case_address(self) -> None:
-        """Mixed-case portfolio address dedupes against lowercase whitelist."""
-        sdai_lower = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
-        sdai_upper = sdai_lower.upper().replace("0X", "0x")
-        obj = self._make_obj(balances={sdai_lower: 5_000_000}, decimals=6)
+        """Mixed-case portfolio address dedupes against lowercase held set."""
+        ousdt_lower = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
+        ousdt_upper = ousdt_lower.upper().replace("0X", "0x")
+        obj = self._make_obj(balances={ousdt_lower: 5_000_000}, decimals=6)
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {
             "portfolio_breakdown": [
-                {"asset": "sDAI", "address": sdai_upper, "value_usd": 50},
+                {"asset": "oUSDT", "address": ousdt_upper, "value_usd": 50},
             ]
         }
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_withdraw_funds.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_withdraw_funds.py
@@ -685,17 +685,17 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_picks_up_idle_token(self) -> None:
         """Empty portfolio_breakdown but safe holds a whitelisted token: queue the swap."""
-        # Real WHITELISTED_ASSETS["optimism"] entry: oUSDT.
-        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
-        obj = self._make_obj(balances={ousdt: 5_000_000})
+        # Real WHITELISTED_ASSETS["optimism"] entry: sDAI.
+        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        obj = self._make_obj(balances={sdai: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {"portfolio_breakdown": []}
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))
         assert len(result) == 1
-        # Verify the swap was built for oUSDT, not for some unrelated token.
+        # Verify the swap was built for sDAI, not for some unrelated token.
         kwargs = obj._build_swap_to_usdc_action.call_args.kwargs
-        assert kwargs["from_token_address"].lower() == ousdt
+        assert kwargs["from_token_address"].lower() == sdai
 
     def test_safe_held_backstop_skips_zero_balance_tokens(self) -> None:
         """Whitelisted tokens with zero balance must not be queued."""
@@ -710,13 +710,13 @@ class TestPrepareSwapToUsdcActionsStandard:
     def test_safe_held_backstop_dedupes_against_portfolio(self) -> None:
         """A token already queued from portfolio_breakdown is not re-queued from the # noqa: D205,D209
         on-chain backstop."""
-        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
-        obj = self._make_obj(balances={ousdt: 5_000_000})
+        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        obj = self._make_obj(balances={sdai: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {
             "portfolio_breakdown": [
-                {"asset": "oUSDT", "address": ousdt, "value_usd": 50},
+                {"asset": "sDAI", "address": sdai, "value_usd": 50},
             ]
         }
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))
@@ -752,8 +752,8 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_skips_dust_below_one_token_unit(self) -> None:
         """Balance below one whole token unit is skipped as dust."""
-        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
-        obj = self._make_obj(balances={ousdt: 999_999}, decimals=6)
+        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        obj = self._make_obj(balances={sdai: 999_999}, decimals=6)
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {"portfolio_breakdown": []}
@@ -763,8 +763,8 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_skips_when_decimals_unavailable(self) -> None:
         """Token is skipped when _get_token_decimals returns None."""
-        ousdt = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
-        obj = self._make_obj(balances={ousdt: 5_000_000})
+        sdai = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        obj = self._make_obj(balances={sdai: 5_000_000})
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         def fake_decimals_none(chain, asset_address):
@@ -780,14 +780,14 @@ class TestPrepareSwapToUsdcActionsStandard:
 
     def test_safe_held_backstop_dedupes_mixed_case_address(self) -> None:
         """Mixed-case portfolio address dedupes against lowercase whitelist."""
-        ousdt_lower = "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189"
-        ousdt_upper = ousdt_lower.upper().replace("0X", "0x")
-        obj = self._make_obj(balances={ousdt_lower: 5_000_000}, decimals=6)
+        sdai_lower = "0x2218a117083f5b482b0bb821d27056ba9c04b1d3"
+        sdai_upper = sdai_lower.upper().replace("0X", "0x")
+        obj = self._make_obj(balances={sdai_lower: 5_000_000}, decimals=6)
         obj._build_swap_to_usdc_action = MagicMock(return_value={"action": "swap"})
 
         portfolio = {
             "portfolio_breakdown": [
-                {"asset": "oUSDT", "address": ousdt_upper, "value_usd": 50},
+                {"asset": "sDAI", "address": sdai_upper, "value_usd": 50},
             ]
         }
         result = _drive(obj._prepare_swap_to_usdc_actions_standard(portfolio))

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeifojiolxc5dz6kmtzf7o73rzfzzoeufvo5mrxedtmg2zjlxx3uqqq
+- valory/liquidity_trader_abci:0.1.0:bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 behaviours:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeidf3bwliegnglphpoclufvbl2rh4ukhb4y5sm3tv6idwu5k4nlrbe
+- valory/liquidity_trader_abci:0.1.0:bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 behaviours:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeibcizh2m3qotn47w3b7x4xel3lgceclytakt5lqkh4t6xqv6tybsq
+- valory/liquidity_trader_abci:0.1.0:bafybeia32dcuuxcytm7v63enlfjpltxcduaxktr7mhe22idap262xbjmjy
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 behaviours:


### PR DESCRIPTION
## What

Restricts the **investable** asset whitelist for the **optimus** (Optimism) and **basius** (Base) agents to an approved stablecoin set, while keeping already-held but de-whitelisted assets detectable and convertible.

### Investable set — `WHITELISTED_ASSETS` (gates *new* positions; consumed by `evaluate_strategy`)

**Optimism (5):**
| Symbol | Address |
| --- | --- |
| USDC (native) | `0x0b2c639c533813f4aa9d7837caf62653d097ff85` |
| sDAI | `0x2218a117083f5b482b0bb821d27056ba9c04b1d3` |
| USDT0 | `0x01bff41798a0bcf287b996046ca68b395dbc1071` |
| USDC.e | `0x7f5c764cbc14f9669b88837ca1490cca17c31607` |
| USDT (bridged) | `0x94b008aa00579c1307b0ef2c499ad98a8ce58e58` |

**Base (6):**
| Symbol | Address |
| --- | --- |
| USDC (native) | `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913` |
| BOLD | `0x03569cc076654f82679c4ba2124d64774781b01d` |
| msUSD | `0x526728dbc96689597f85ae4cd716d4f7fccbae9d` |
| frxUSD | `0xe5020a6d073a794b6e7f05678707de47986fb0b6` |
| eUSD | `0xcfa3ef56d303ae4faaba0592388f19d7c3399fb4` |
| axlUSDC | `0xeb466342c4d449bc9f53a865d5cb90586f405215` |

Mode (legacy) is left unchanged.

## Investable vs. held/sweep split (review fix)

`WHITELISTED_ASSETS` is a single dict that drove **both** investability and on-chain detection/sweep. Removing oUSDT from it would also drop it from balance detection and the withdraw sweep — stranding oUSDT that existing optimus agents still hold (no loss; invisible during SafeApi gaps and not auto-converted). To avoid that, the concern is now split in `liquidity_trader_abci/behaviours/base.py`:

- **`WHITELISTED_ASSETS`** — the investable set above. Gates *new* positions only (`evaluate_strategy`).
- **`LEGACY_HELD_ASSETS`** — assets removed from investment but possibly still held (currently **oUSDT** on Optimism).
- **`HELD_ASSETS`** — superset (investable + legacy held), consumed by the three detection/sweep sites: the last-known-balance tracker, the on-chain balance backstop (`_supplement_with_onchain_whitelisted_balances`), and the withdraw sweep-to-USDC fallback (`_prepare_swap_to_usdc_actions_standard`).

Net: no new oUSDT investment, but held oUSDT stays **visible, convertible, and priceable**. `COIN_ID_MAPPING` is intentionally left intact so held-but-de-whitelisted tokens can still be priced via CoinGecko. Drop the `LEGACY_HELD_ASSETS` entry in a follow-up once on-chain oUSDT reaches zero.

## Runtime mechanism (corrected)

The real consumers (investability, detection, sweep) read the **module constants** (`WHITELISTED_ASSETS` / `HELD_ASSETS`) directly, so the trim takes effect immediately for all agents. The JSON-backed `self.whitelisted_assets` is **not** reconciled from the constant — `fetch_strategies.py:315-319` only seeds it from `WHITELISTED_ASSETS` when the persisted file is empty; otherwise existing agents keep reading their (now stale) `whitelisted_assets.json`. That stale JSON is only the price-drop tracker's state and does not gate the behaviour this PR changes. (Corrects an earlier, inaccurate claim that the JSON is reconciled from the constant.)

## Tests
- Backstop and sweep tests now reference `HELD_ASSETS`, so they cover the legacy-held **oUSDT** path the trim actually changes.
- New `TestWhitelistInvariants` pins the exact investable membership per chain, asserts oUSDT is **not** investable but **remains** in `HELD_ASSETS`/`LEGACY_HELD_ASSETS`, and checks the `HELD_ASSETS ⊇ WHITELISTED_ASSETS` invariant.
- `test_base.py`, `test_withdraw_funds.py`, `test_evaluate_strategy.py`, `test_fetch_strategies.py` — **1455 passed**.
- Re-locked package hashes (`autonomy packages lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Base de-whitelist asymmetry (intentional)

This PR also removes 6 tokens from the Base investable set (USDT `0xfde4…`, USDe, DOLA, MUSD, USR, USDz) without adding them to `LEGACY_HELD_ASSETS`. That is deliberate: **basius (Base) is not launched yet**, so no agent holds any of them — there are no Base balances to strand, so the oUSDT-style held/sweep handling is unnecessary. If basius launches and any held token is later de-whitelisted, it should be added to `LEGACY_HELD_ASSETS["base"]` then. The Base investable set is pinned by `TestWhitelistInvariants` to prevent drift.