### PR TITLE
fix(optimus_abci): order MechParams before TerminationParams so multisend_address resolves

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,9 +24,9 @@
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeid6mul7gkwnusgbquoqau5lrncq7trxbdytsgtw724o7snhuioseq",
-        "skill/valory/optimus_abci/0.1.0": "bafybeic5k7nxlwfgcg7hdyqtkzl6rap4eousifcmvlu7vzmc4pn3e6uqvu",
-        "agent/valory/optimus/0.1.0": "bafybeihbzq72xnl7fpnsh4grngzpbgoqudxwyyn7gwvuz6htjd2eyygizi",
-        "service/valory/optimus/0.1.0": "bafybeia32pijmauwrx3ek2vsqsz26meydchc5bndyndcpgrx5vqcoo6wsa"
+        "skill/valory/optimus_abci/0.1.0": "bafybeifne3lrjcnotv3fwz3p7iu3qf4pcbhuxyt5dz65irn4tsa2gqdcd4",
+        "agent/valory/optimus/0.1.0": "bafybeihdlghgcsy5oambd44bmuvawoypfrsgylzm7fvmxglz4ebvr56q6m",
+        "service/valory/optimus/0.1.0": "bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -70,7 +70,7 @@ skills:
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 - valory/liquidity_trader_abci:0.1.0:bafybeid6mul7gkwnusgbquoqau5lrncq7trxbdytsgtw724o7snhuioseq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeic5k7nxlwfgcg7hdyqtkzl6rap4eousifcmvlu7vzmc4pn3e6uqvu
+- valory/optimus_abci:0.1.0:bafybeifne3lrjcnotv3fwz3p7iu3qf4pcbhuxyt5dz65irn4tsa2gqdcd4
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeihbzq72xnl7fpnsh4grngzpbgoqudxwyyn7gwvuz6htjd2eyygizi
+agent: valory/optimus:0.1.0:bafybeihdlghgcsy5oambd44bmuvawoypfrsgylzm7fvmxglz4ebvr56q6m
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/optimus_abci/models.py
+++ b/packages/valory/skills/optimus_abci/models.py
@@ -95,15 +95,24 @@ MULTIPLIER = 40
 
 
 class Params(  # pylint: disable=too-many-ancestors
+    MechParams,
     TerminationParams,
     LiquidityTraderParams,
-    MechParams,
 ):
     """A model to represent params for multiple abci apps.
 
     Also mixes in ``MechParams`` so the composed ``mech_interact_abci``
     behaviours can read their marketplace/request config off the single shared
     ``self.context.params`` in this composition skill.
+
+    ``MechParams`` is listed first on purpose. Both it and ``TerminationParams``
+    consume ``multisend_address``, but ``TerminationParams`` reads it via
+    ``_ensure`` (which *pops* the key off ``kwargs``) while ``MechParams`` reads
+    it non-destructively via ``kwargs.get``. With ``TerminationParams`` ahead of
+    ``MechParams`` in the MRO the pop runs first, so ``MechParams`` sees ``None``
+    and ``enforce(multisend_address is not None)`` raises "Multisend address not
+    specified!" at agent load. Running ``MechParams`` first lets it read the
+    value before ``TerminationParams`` pops it.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -61,7 +61,7 @@ fingerprint:
   dialogues.py: bafybeicqqxvsqffqeo6cnp4rok45c74yb2a3m5a7twuzinc7ruk3o2635y
   fsm_specification.yaml: bafybeiffslnjerjd3ezc5bih7fg5hseuj7qxscnjt6b3hltmyocsa5kxvq
   handlers.py: bafybeigq53sq7g4wlxbyl4kodaxpqi6sxom3nwjlfvydw4ujxzmu4r3glq
-  models.py: bafybeibv4mboeszbjvp2nfh2hrxrkpxknjcmzsxxfvnzqk6fm6lev67hre
+  models.py: bafybeibtlzwyvh33wzcqgvxkil3ecl2cgvuu5fr5dgio3525nphflbp5oe
   modius-ui-build/README.md: bafybeie62j2zjin57jc3npbxbpomfs6p4n7jkafpu2bniyyx2m3saq7b5a
   modius-ui-build/assets/agentsfun-chat-CQO2MvlO.png: bafybeibm5nhmhfa54gimrsjt7pupvw3bkg2ayr6nul5o5krlj67ivh26oy
   modius-ui-build/assets/index-DPlzseC6.js: bafybeihn3b6hvbogyassji7f22tao4hqrvypoan2xqv5dlbbkolq6icphy


### PR DESCRIPTION
## Problem

The release-only `make check-agent-runner` step fails on `v0.12.0-rc2` (the first release to include the new mech path from #342) when the packaged agent loads:

```
File "vendor/valory/skills/mech_interact_abci/models.py", line 262, in __init__
    enforce(multisend_address is not None, "Multisend address not specified!")
aea.exceptions.AEAEnforceError: Multisend address not specified!
[FAIL] Did not find 'Starting AEA' within 80s
```

This isn't caught by the normal PR CI (the binary runner check only runs in the release flow) or by unit tests (they construct params from mocks).

## Root cause

`optimus_abci`'s composed `Params` mixes in both `TerminationParams` and `MechParams`, and **both consume `multisend_address`**:

- `TerminationParams.__init__` reads it via `self._ensure("multisend_address", kwargs, str)` — and `_ensure` **pops** the key off `kwargs`.
- `MechParams.__init__` reads it non-destructively via `kwargs.get("multisend_address")`.

The MRO was `Params(TerminationParams, LiquidityTraderParams, MechParams)`, so `TerminationParams` ran first and popped the key; by the time `MechParams` (last) ran, `kwargs.get` returned `None` and its `enforce` raised. (`liquidity_trader` is unaffected — it uses the per-chain `multisend_contract_addresses` map, not this single param.)

## Fix

Reorder the MRO so `MechParams` precedes `TerminationParams`:

```python
class Params(MechParams, TerminationParams, LiquidityTraderParams):
```

`MechParams` now reads `multisend_address` (non-destructively) before `TerminationParams` pops it. Hashes relocked accordingly (`optimus_abci` / agent / service).

## Verification (local)

- Rebuilt the agent from the fixed packages and ran it with only `STORE_PATH` set (as `check-agent-runner` does) → reaches **`Starting AEA … in 'async' mode`**, no `Multisend address not specified!`.
- `optimus_abci` + `liquidity_trader` tests: **pass**.
- `tomte tox`: `check-hash`, `check-packages`, `check-abci-docstrings`, `check-abciapp-specs`, `check-handlers`, `black-check`, `isort-check`, `flake8`, `darglint`, `mypy`, `pylint` — **all green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)