### PR TITLE
fix(release): pin agent-runner build to a single dev agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,18 @@ build-agent-runner-mac: uv-install  agent
 	./dist/agent_runner_bin$(EXE_SUFFIX) --version
 
 
+# Multiple dev agents (e.g. optimus and basius) share the same skill code,
+# so the release binary is built once against optimus and re-used. Pearl
+# downloads the actual agent it wants at install time via the service
+# template hash. Override RELEASE_AGENT_PUBLIC_ID locally if you need to
+# build against a different agent.
+RELEASE_AGENT_PUBLIC_ID ?= agent/valory/optimus/0.1.0
+
 ./hash_id: ./packages/packages.json
-	cat ./packages/packages.json | jq -r '.dev | to_entries[] | select(.key | startswith("agent/")) | .value' > ./hash_id
+	cat ./packages/packages.json | jq -r --arg agent_key '$(RELEASE_AGENT_PUBLIC_ID)' '.dev[$$agent_key]' > ./hash_id
 
 ./agent_id: ./packages/packages.json
-	cat ./packages/packages.json | jq -r '.dev | to_entries[] | select(.key | startswith("agent/")) | .key | sub("^agent/"; "")' > ./agent_id
+	echo '$(RELEASE_AGENT_PUBLIC_ID)' | sed 's|^agent/||' > ./agent_id
 
 ./agent.zip: ./agent
 	zip -r ./agent.zip ./agent


### PR DESCRIPTION
## Summary
- The `v0.12.0-rc4` release-tag build of `build-agent-runner (ubuntu-24.04)` failed with `autonomy fetch ... Error: Got unexpected extra argument (bafybeicvsp5zraysyjg4lhq7hg2igcwax7mmuogmi4ertu3swsnovxiyey)`. Run: https://github.com/valory-xyz/optimus/actions/runs/27949569727/job/82702952497.
- Root cause: the Makefile's `./hash_id` and `./agent_id` targets selected every `dev` agent from `packages/packages.json`. That assumed exactly one dev agent. The new `valory/basius` agent (PR #344) made it two, so `cat ./hash_id` expanded to two hashes and `autonomy fetch` rejected the second.
- Fix: introduce `RELEASE_AGENT_PUBLIC_ID` (default `agent/valory/optimus/0.1.0`) and look up that one entry. `./hash_id` and `./agent_id` now each contain exactly one line, matching what `make ./agent/ethereum_private_key.txt` and the downstream pyinstaller steps expect.
- The binary built off optimus runs basius equally well because they share all skill code. Pearl downloads the actual agent it wants at install time via the service template hash. To rebuild a release binary against a different agent locally: `make build-agent-runner RELEASE_AGENT_PUBLIC_ID=agent/valory/basius/0.1.0`.

## Test plan
- [x] `make hash_id` writes one line locally (the optimus agent hash)
- [x] `make agent_id` writes one line locally (`valory/optimus/0.1.0`)
- [ ] Re-cut the release tag (or re-run the failed job manually) and confirm `build-agent-runner` proceeds past `make key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)