### PR TITLE
chore(services): drop literal CoinGecko key default and Tenderly virtual-fork RPC defaults

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "skill/valory/optimus_abci/0.1.0": "bafybeifne3lrjcnotv3fwz3p7iu3qf4pcbhuxyt5dz65irn4tsa2gqdcd4",
         "agent/valory/optimus/0.1.0": "bafybeihdlghgcsy5oambd44bmuvawoypfrsgylzm7fvmxglz4ebvr56q6m",
         "agent/valory/basius/0.1.0": "bafybeicvsp5zraysyjg4lhq7hg2igcwax7mmuogmi4ertu3swsnovxiyey",
-        "service/valory/optimus/0.1.0": "bafybeie2zrvd5mfswtktaagjtvhamnl4lv53hetu6skrzytv73sxn6joie",
-        "service/valory/basius/0.1.0": "bafybeiehwn2lc773hlwybuo6hwce556pnozk7z7c3cn25reegaefzcaoe4"
+        "service/valory/optimus/0.1.0": "bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu",
+        "service/valory/basius/0.1.0": "bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -145,7 +145,7 @@ models:
     args:
       token_price_endpoint: ${COINGECKO_TOKEN_PRICE_ENDPOINT:str:/api/v3/simple/token_price/{asset_platform_id}?contract_addresses={token_address}&vs_currencies=usd}
       coin_price_endpoint: ${COINGECKO_COIN_PRICE_ENDPOINT:str:/api/v3/simple/price?ids={coin_id}&vs_currencies=usd}
-      api_key: ${COINGECKO_API_KEY:str:CG-mf5xZnGELpSXeSqmHDLY2nNU}
+      api_key: ${COINGECKO_API_KEY:str:null}
       requests_per_minute: ${COINGECKO_REQUESTS_PER_MINUTE:int:30}
       credits: ${COINGECKO_CREDITS:int:10000}
       rate_limited_code: ${COINGECKO_RATE_LIMITED_CODE:int:429}
@@ -168,17 +168,17 @@ config:
       poa_chain: ${ETHEREUM_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${ETHEREUM_LEDGER_PRICING:str:eip1559}
     base:
-      address: ${BASE_LEDGER_RPC:str:https://virtual.arbitrum.rpc.tenderly.co/8973f254-1594-4a82-8e26-25a10a01bf46}
+      address: ${BASE_LEDGER_RPC:str:https://mainnet.base.org}
       chain_id: ${BASE_LEDGER_CHAIN_ID:int:8453}
       poa_chain: ${BASE_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${BASE_LEDGER_PRICING:str:eip1559}
     optimism:
-      address: ${OPTIMISM_LEDGER_RPC:str:https://virtual.arbitrum.rpc.tenderly.co/8973f254-1594-4a82-8e26-25a10a01bf46}
+      address: ${OPTIMISM_LEDGER_RPC:str:https://mainnet.optimism.io}
       chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
       poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
     mode:
-      address: ${MODE_LEDGER_RPC:str:https://virtual.mode.rpc.tenderly.co/f1d63db5-da55-4383-bbed-54a6edbb0ee2}
+      address: ${MODE_LEDGER_RPC:str:https://mainnet.mode.network/}
       chain_id: ${MODE_LEDGER_CHAIN_ID:int:34443}
       poa_chain: ${MODE_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${MODE_LEDGER_PRICING:str:eip1559}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -145,7 +145,7 @@ models:
     args:
       token_price_endpoint: ${COINGECKO_TOKEN_PRICE_ENDPOINT:str:/api/v3/simple/token_price/{asset_platform_id}?contract_addresses={token_address}&vs_currencies=usd}
       coin_price_endpoint: ${COINGECKO_COIN_PRICE_ENDPOINT:str:/api/v3/simple/price?ids={coin_id}&vs_currencies=usd}
-      api_key: ${COINGECKO_API_KEY:str:CG-mf5xZnGELpSXeSqmHDLY2nNU}
+      api_key: ${COINGECKO_API_KEY:str:null}
       requests_per_minute: ${COINGECKO_REQUESTS_PER_MINUTE:int:30}
       credits: ${COINGECKO_CREDITS:int:10000}
       rate_limited_code: ${COINGECKO_RATE_LIMITED_CODE:int:429}
@@ -168,17 +168,17 @@ config:
       poa_chain: ${ETHEREUM_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${ETHEREUM_LEDGER_PRICING:str:eip1559}
     base:
-      address: ${BASE_LEDGER_RPC:str:https://virtual.arbitrum.rpc.tenderly.co/8973f254-1594-4a82-8e26-25a10a01bf46}
+      address: ${BASE_LEDGER_RPC:str:https://mainnet.base.org}
       chain_id: ${BASE_LEDGER_CHAIN_ID:int:8453}
       poa_chain: ${BASE_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${BASE_LEDGER_PRICING:str:eip1559}
     optimism:
-      address: ${OPTIMISM_LEDGER_RPC:str:https://virtual.arbitrum.rpc.tenderly.co/8973f254-1594-4a82-8e26-25a10a01bf46}
+      address: ${OPTIMISM_LEDGER_RPC:str:https://mainnet.optimism.io}
       chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
       poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
     mode:
-      address: ${MODE_LEDGER_RPC:str:https://virtual.mode.rpc.tenderly.co/f1d63db5-da55-4383-bbed-54a6edbb0ee2}
+      address: ${MODE_LEDGER_RPC:str:https://mainnet.mode.network/}
       chain_id: ${MODE_LEDGER_CHAIN_ID:int:34443}
       poa_chain: ${MODE_LEDGER_IS_POA_CHAIN:bool:false}
       default_gas_price_strategy: ${MODE_LEDGER_PRICING:str:eip1559}


### PR DESCRIPTION
## Summary
Two long-lived defaults in `services/optimus/service.yaml` (inherited into `services/basius/service.yaml` when it was forked) should be tightened. Fix both files together so the cleanup is symmetric.

**1. CoinGecko `api_key` default → `null`**

The agent-side `aea-config.yaml` already defaults to `null`. Align the service-side default with it; operators set `COINGECKO_API_KEY` per deployment, so the existing default was dead config for any real install.

**2. Tenderly virtual-fork RPC defaults for base / optimism / mode → public mainnet endpoints**

`curl ... eth_chainId` on the previous base/optimism URL returns `0xa4b1` (Arbitrum One), while the YAML declares `chain_id: 8453` / `10`. Any non-Pearl deploy that fell through to these defaults would fail EIP-155 signing on the first tx because the reported chain id wouldn't match the configured one. Pearl always overrides via `env_variables`, so this never bit in production, but the defaults should be self-consistent. Mainnet endpoints fix that.

Ethereum left untouched: the existing default is a mainnet fork (chain id matches) and the public mainnet alternatives are heavily rate-limited.

## Follow-up for whoever lands this
**Bump Pearl hashes.** The service hashes change in this PR. Once merged, Pearl needs another bump of `BABYDEGEN_COMMON_TEMPLATE.hash` to `bafybeih2ltyvqxllohrguokclyoj46updpap2byeknjrr34p6dm74mhemu` and `BASIUS_TEMPLATE_RELEASE.hash` to `bafybeicqm5hp6ag226oxwks2npx4ybacvaohfg2rm7ellfxqh2dx3m3zzi`. Both already pushed to IPFS.

## Test plan
- [x] `autonomy packages lock --check` passes
- [x] Both new service hashes pushed to IPFS
- [ ] Boot Basius in Pearl from the rc that consumes these new hashes — confirm it still works end-to-end with Pearl's env-var overrides in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)