### PR TITLE
fix(basius): point mech-marketplace config at Base deployment

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,9 +26,9 @@
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeie2dbrd52jdhbkyed2yiznmzgvyf6gtvyr5raaiofidgn7ry2a5ci",
         "skill/valory/optimus_abci/0.1.0": "bafybeiemjkzl2m4ynpfgnqnnode2tqd7hoiagrfyhnegg3ignyrmjtk3dm",
         "agent/valory/optimus/0.1.0": "bafybeiheh5jp4iu63yt4g5qnhl4c7z4rp4rawlaoehrn2u3rxciieg52ia",
-        "agent/valory/basius/0.1.0": "bafybeicyoy2n6lldqnsj5l55gxp6x3k4h7lqvyvfpiilu7jodesnt2jf5q",
+        "agent/valory/basius/0.1.0": "bafybeihukrzz7fkwe3oz7qduycz65xmwpmkjqki44j5cjjnsnfp2i2nrci",
         "service/valory/optimus/0.1.0": "bafybeidbihpktbk6qxhi5y2edudokisyywnm5ny4vuawxmmd3igwq5gv34",
-        "service/valory/basius/0.1.0": "bafybeie472ikfyfbtavxij2g5t5pwi3dz6wwi36ganu5o25dgnzagjg53m"
+        "service/valory/basius/0.1.0": "bafybeibz2fnub3miiydey7sdvfzmofs3r5okncfz4l7bw45hyxaou7z5d4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -323,16 +323,16 @@ models:
       mech_tool: ${MECH_TOOL:str:openai-gpt-4o-2024-08-06}
       mech_request_prompt: ${MECH_REQUEST_PROMPT:str:Optimus staking activity request.}
       multisend_batch_size: ${MECH_MULTISEND_BATCH_SIZE:int:1}
-      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x650C77F49cFa69e2AC1990A6B4585C322B012D0d}
+      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0xe535D7AcDEeD905dddcb5443f41980436833cA2B}
       ipfs_address: ${MECH_IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}
-      mech_chain_id: ${MECH_CHAIN_ID:str:optimism}
+      mech_chain_id: ${MECH_CHAIN_ID:str:base}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x4200000000000000000000000000000000000006}
       mech_interaction_sleep_time: ${MECH_INTERACTION_SLEEP_TIME:int:10}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x650C77F49cFa69e2AC1990A6B4585C322B012D0d","priority_mech_service_id":194,"response_timeout":300,"use_dynamic_mech_selection":false}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_service_id":112,"response_timeout":300,"use_dynamic_mech_selection":false}}
       agent_registry_address: ${MECH_AGENT_REGISTRY_ADDRESS:str:0x0000000000000000000000000000000000000000}
       use_acn_for_delivers: ${USE_ACN_FOR_DELIVERS:bool:false}
-      valid_mechs: ${VALID_MECHS:list:["0x650C77F49cFa69e2AC1990A6B4585C322B012D0d"]}
+      valid_mechs: ${VALID_MECHS:list:["0xe535D7AcDEeD905dddcb5443f41980436833cA2B"]}
       penalize_mech_time_window: ${MECH_PENALIZE_TIME_WINDOW:int:1800}
       deliveries_lookback_days: ${MECH_DELIVERIES_LOOKBACK_DAYS:int:30}
       store_path: ${STORE_PATH:str:/data}

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeicyoy2n6lldqnsj5l55gxp6x3k4h7lqvyvfpiilu7jodesnt2jf5q
+agent: valory/basius:0.1.0:bafybeihukrzz7fkwe3oz7qduycz65xmwpmkjqki44j5cjjnsnfp2i2nrci
 number_of_agents: 1
 deployment:
   agent:
@@ -85,16 +85,16 @@ models:
       mech_tool: ${MECH_TOOL:str:openai-gpt-4o-2024-08-06}
       mech_request_prompt: ${MECH_REQUEST_PROMPT:str:Optimus staking activity request.}
       multisend_batch_size: ${MECH_MULTISEND_BATCH_SIZE:int:1}
-      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x650C77F49cFa69e2AC1990A6B4585C322B012D0d}
+      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0xe535D7AcDEeD905dddcb5443f41980436833cA2B}
       ipfs_address: ${MECH_IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}
       mech_chain_id: ${MECH_CHAIN_ID:str:base}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x4200000000000000000000000000000000000006}
       mech_interaction_sleep_time: ${MECH_INTERACTION_SLEEP_TIME:int:10}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x650C77F49cFa69e2AC1990A6B4585C322B012D0d","priority_mech_service_id":194,"response_timeout":300,"use_dynamic_mech_selection":false}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_service_id":112,"response_timeout":300,"use_dynamic_mech_selection":false}}
       agent_registry_address: ${MECH_AGENT_REGISTRY_ADDRESS:str:0x0000000000000000000000000000000000000000}
       use_acn_for_delivers: ${USE_ACN_FOR_DELIVERS:bool:false}
-      valid_mechs: ${VALID_MECHS:list:["0x650C77F49cFa69e2AC1990A6B4585C322B012D0d"]}
+      valid_mechs: ${VALID_MECHS:list:["0xe535D7AcDEeD905dddcb5443f41980436833cA2B"]}
       penalize_mech_time_window: ${MECH_PENALIZE_TIME_WINDOW:int:1800}
       deliveries_lookback_days: ${MECH_DELIVERIES_LOOKBACK_DAYS:int:30}
       store_path: ${STORE_PATH:str:/data/}


### PR DESCRIPTION
## Summary
basius agent and service inherited mech-marketplace addresses from optimus, all pointing at the Optimism mech deployment. `mech_interact_abci/models.py:267-271, 287-327` treats these as mandatory chain-specific config — no auto-discovery. With `use_mech_marketplace=true` and `use_dynamic_mech_selection=false` (both defaults), `priority_mech_address` and `mech_marketplace_address` are read directly and calls would land on contracts that either don't exist at those addresses on Base or are different contracts entirely. Once PR #347 unblocks `HttpHandler.setup`, this is the next failure the agent would hit when the staking-activity path reaches `MechRequestRound`.

## Source of the new values
`mech-deployments/deployments/base_mech.env`:

| Field | Value |
|---|---|
| `mech_marketplace_address` | `0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020` |
| `priority_mech_address` | `0xe535D7AcDEeD905dddcb5443f41980436833cA2B` |
| `priority_mech_service_id` | `112` (the Base mech's on-chain service id) |
| `valid_mechs` | `["0xe535D7AcDEeD905dddcb5443f41980436833cA2B"]` |
| `mech_contract_address` | `0xe535D7AcDEeD905dddcb5443f41980436833cA2B` (functionally ignored while `use_mech_marketplace=true` per `models.py:323`, but kept consistent so debugging / future toggling reads correctly) |
| `mech_chain_id` | `base` (was already `base` in service.yaml; aea-config now matches) |

`mech_wrapped_native_token_address` stays at `0x4200000000000000000000000000000000000006` — WETH shares that L2 standard address on both Optimism and Base.

## Stacking
Based on `fix/rounds-info-add-missing-mech-rounds` (PR #347). Once #347 merges, retarget to main.

## Pearl follow-up
Service hash changes. After this merges and an rc tag goes out, Pearl needs another `BASIUS_TEMPLATE_RELEASE.hash` bump. New basius service hash already pushed to IPFS: `bafybeibz2fnub3miiydey7sdvfzmofs3r5okncfz4l7bw45hyxaou7z5d4`.

## Test plan
- [x] `autonomy packages lock --check` passes
- [x] New basius service hash pushed to IPFS
- [ ] Boot Basius on Base from the rc that consumes these hashes — confirm the agent gets past `MechRequestRound` (the next failure mode after the KeyError fix from #347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)