### PR TITLE
fix(basius): point mechs_subgraph at marketplace-base on the autonolas proxy

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,9 +26,9 @@
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
         "agent/valory/optimus/0.1.0": "bafybeifcj4v3lke5l7ovizcqglcplfdngiszgil2cplq2l4sq652b47jaq",
-        "agent/valory/basius/0.1.0": "bafybeigki6o6zw7nm53xm7vfxd2npy5qkxukfnmjfgrexkddsra3rbgnxi",
+        "agent/valory/basius/0.1.0": "bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq",
         "service/valory/optimus/0.1.0": "bafybeih5u7loukh2eah24dvshbebulsy425fcsjarncssrvx6i37h7ejqm",
-        "service/valory/basius/0.1.0": "bafybeigrgrm66iriunfrflz2ybmeg4efmjj2xaiqnwzpo7ygc6dte2tqnm"
+        "service/valory/basius/0.1.0": "bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -226,6 +226,9 @@ models:
       coingecko_server_base_url: ${str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${str:optimism}
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}
   params:
     args:
       cleanup_history_depth: 1

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeigki6o6zw7nm53xm7vfxd2npy5qkxukfnmjfgrexkddsra3rbgnxi
+agent: valory/basius:0.1.0:bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq
 number_of_agents: 1
 deployment:
   agent:
@@ -157,6 +157,9 @@ models:
       coingecko_server_base_url: ${COINGECKO_SERVER_BASE_URL:str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${COINGECKO_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${GENAI_NETWORK_SELECTOR:str:base}
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}
 ---
 public_id: valory/ledger:0.19.0
 type: connection


### PR DESCRIPTION
## Summary

Basius runs on Base with the Base mech marketplace `0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020`, but `optimus_abci/skill.yaml:481` hardcodes the `mechs_subgraph.url` at `https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism`. The Optimism proxy doesn't index Base marketplace mechs, so every `MechInformationBehaviour.fetch_mechs_info()` call returned `[]`. `mech_info.py:156` then set `last_failure_reason = "valid_mech_list_empty"`, the round emitted `NONE`, and the composed Optimus FSM routed `(MechInformationRound, NONE) → MechVersionDetectionRound` forever — no mech request was ever submitted, so `mapRequestCounts` stayed at 0 and the staking KPI never got ticked.

Adds a `mechs_subgraph` model override in `basius/service.yaml` and `basius/aea-config.yaml` pointing at the Base proxy, made env-overridable via `MECHS_SUBGRAPH_URL` for operator flexibility. Optimus is untouched.

```yaml
mechs_subgraph:
  args:
    url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}
```

## Verified before the change

- `POST {marketplace-base}/_meta` → `HTTP 200`, current Base block `47714957`.
- The priority mech `0xe535D7AcDEeD905dddcb5443f41980436833cA2B` is indexed at id `112` with `10090` total deliveries and a non-null metadata CID — so the exact query `mech_info.py` issues (`address_in: [...]`, `service_: {totalDeliveries_gt: 0}`, recent `blockTimestamp_gt`) will return a non-empty result on the first call.
- Pattern matches `trader`'s approach: per-chain marketplace subgraph URLs, env-overridable. Optimus already uses `marketplace-optimism`; Basius now uses `marketplace-base`.

## Test plan
- [ ] Boot a Basius Base agent past `staking_threshold_period` periods.
- [ ] Observe `Event.MECH_REQUEST_NEEDED → MechVersionDetectionRound → MechInformationRound` resolves with `Updated mechs' information: ...` (non-empty) instead of the empty-list infinite loop.
- [ ] After mech request settles, observe `mapRequestCounts` increment on-chain at the activity checker.

## Out of scope
- Making the URL env-overridable in `optimus_abci/skill.yaml` itself (Optimus continues to default to `marketplace-optimism` via the unchanged skill default).
- Any fallback path when the subgraph is empty — kept as-is for now; we can revisit if the Base subgraph turns out to be flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)