### PR TITLE
fix(mech): override mechs_subgraph under mech_interact_abci skill for basius + optimus

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,9 +26,9 @@
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
         "agent/valory/optimus/0.1.0": "bafybeifcj4v3lke5l7ovizcqglcplfdngiszgil2cplq2l4sq652b47jaq",
-        "agent/valory/basius/0.1.0": "bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq",
+        "agent/valory/basius/0.1.0": "bafybeibdbc374femx4tfusgpjoncupng7iklqloiuyayb3irjazpnlunmi",
         "service/valory/optimus/0.1.0": "bafybeih5u7loukh2eah24dvshbebulsy425fcsjarncssrvx6i37h7ejqm",
-        "service/valory/basius/0.1.0": "bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama"
+        "service/valory/basius/0.1.0": "bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,9 +25,9 @@
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
-        "agent/valory/optimus/0.1.0": "bafybeifcj4v3lke5l7ovizcqglcplfdngiszgil2cplq2l4sq652b47jaq",
+        "agent/valory/optimus/0.1.0": "bafybeihpghd65qeiepn5e4r4btqprghv44qgssoqtw26gwdch4bmlpnbfq",
         "agent/valory/basius/0.1.0": "bafybeibdbc374femx4tfusgpjoncupng7iklqloiuyayb3irjazpnlunmi",
-        "service/valory/optimus/0.1.0": "bafybeih5u7loukh2eah24dvshbebulsy425fcsjarncssrvx6i37h7ejqm",
+        "service/valory/optimus/0.1.0": "bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4",
         "service/valory/basius/0.1.0": "bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy"
     },
     "third_party": {

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -375,3 +375,10 @@ models:
       safe_api_url: ${SAFE_API_URL:str:https://rpc-gate.autonolas.tech/safe/tx-service}
       safe_api_chain_slugs: ${SAFE_API_CHAIN_SLUGS:str:{"optimism":"oeth","base":"base"}}
       mode_native_explorer_url: ${MODE_NATIVE_EXPLORER_URL:str:https://explorer.mode.network/api}
+---
+public_id: valory/mech_interact_abci:0.1.0
+type: skill
+models:
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -226,6 +226,9 @@ models:
       coingecko_server_base_url: ${str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${str:optimism}
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}
   params:
     args:
       cleanup_history_depth: 1
@@ -372,3 +375,10 @@ models:
       safe_api_url: ${SAFE_API_URL:str:https://rpc-gate.autonolas.tech/safe/tx-service}
       safe_api_chain_slugs: ${SAFE_API_CHAIN_SLUGS:str:{"optimism":"oeth","base":"base"}}
       mode_native_explorer_url: ${MODE_NATIVE_EXPLORER_URL:str:https://explorer.mode.network/api}
+---
+public_id: valory/mech_interact_abci:0.1.0
+type: skill
+models:
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq
+agent: valory/basius:0.1.0:bafybeibdbc374femx4tfusgpjoncupng7iklqloiuyayb3irjazpnlunmi
 number_of_agents: 1
 deployment:
   agent:
@@ -157,6 +157,13 @@ models:
       coingecko_server_base_url: ${COINGECKO_SERVER_BASE_URL:str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${COINGECKO_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${GENAI_NETWORK_SELECTOR:str:base}
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}
+---
+public_id: valory/mech_interact_abci:0.1.0
+type: skill
+models:
   mechs_subgraph:
     args:
       url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeifcj4v3lke5l7ovizcqglcplfdngiszgil2cplq2l4sq652b47jaq
+agent: valory/optimus:0.1.0:bafybeihpghd65qeiepn5e4r4btqprghv44qgssoqtw26gwdch4bmlpnbfq
 number_of_agents: 1
 deployment:
   agent:
@@ -157,6 +157,16 @@ models:
       coingecko_server_base_url: ${COINGECKO_SERVER_BASE_URL:str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${COINGECKO_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${GENAI_NETWORK_SELECTOR:str:optimism}
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}
+---
+public_id: valory/mech_interact_abci:0.1.0
+type: skill
+models:
+  mechs_subgraph:
+    args:
+      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}
 ---
 public_id: valory/ledger:0.19.0
 type: connection


### PR DESCRIPTION
## Summary

Follow-up to #350. That PR overrode `mechs_subgraph.url` under the `valory/optimus_abci` skill stanza only. Production log showed the override didn't take effect — the agent still hit `marketplace-gnosis` (the `mech_interact_abci` default), got `[]`, and looped forever on `(MechInformationRound, NONE) → MechVersionDetectionRound`.

This PR fixes the wiring for both basius and optimus.

## Diagnosis

```
17:49:18,193  Entered 'mech_information_round'
17:49:18,298  Retrieved mechs' information: [].   (105ms — HTTP call did fire)
17:49:18,298  Failed to fetch mech information for the marketplace.
17:49:19,225  'mech_information_round' done with event: Event.NONE
```

105 ms between round entry and the empty-result log — so the HTTP fetch *did* run (it's `requests.py:117`, after `process_response`). The URL was the wrong one. Direct probe:

```
marketplace-gnosis  + valid_mechs=["0xe535..."]  → {"data":{"meches":[]}}
marketplace-base    + valid_mechs=["0xe535..."]  → returns the priority mech (id 112, 10090 deliveries)
```

`MechInformationBehaviour` reads `self.context.mechs_subgraph`. The behaviour lives in the `mech_interact_abci` skill, so the model lookup resolves against `mech_interact_abci`'s `SkillContext` — *not* `optimus_abci`'s. This is independent of how `self.params` works (`optimus_abci.Params` mixes in `MechParams`, so `self.params.mech_marketplace_config` *did* return the Base address — confirmed by the `Detecting marketplace compatibility for ... 0xf24eE42...` log line).

## Fix

For each agent, add the `mechs_subgraph.url` override under a dedicated `valory/mech_interact_abci` skill stanza in both the service.yaml and the agent's aea-config.yaml. Keep the `optimus_abci` stanza from #350 as a defensive belt-and-braces — the two contexts are independent, and either could be the lookup target depending on how the composed FSM wires the model registration.

- **basius**: → `marketplace-base`
- **optimus**: → `marketplace-optimism`

Both env-overridable via `MECHS_SUBGRAPH_URL`.

## Verified before push

- `POST {marketplace-base}/_meta` → HTTP 200, current Base block ~47.7M.
- Basius priority mech `0xe535D7AcDEeD905dddcb5443f41980436833cA2B` indexed at id `112` with `10090` deliveries and a non-empty metadata CID — `populate_tools` + IPFS manifest will succeed.
- `marketplace-optimism` healthy at Optimism block ~153M.
- `autonomy packages lock --check` passes.

## Known follow-up (not in this PR)

Optimus's priority mech `0x650C77F49cFa69e2AC1990A6B4585C322B012D0d` on `marketplace-optimism` has `totalDeliveries=0` and empty metadata today. The mech-info query filters `service_: {totalDeliveries_gt: 0}` so it would still return `[]` even with this fix — the mech needs at least one delivery to be discoverable to its own agent (chicken-and-egg). Doesn't block anything today since Optimus is still on the old vanity-tx staking regime; the URL override is in place so the wire is correct once Optimus migrates.

## Test plan
- [ ] Pearl deploys this agent hash (next rc bump).
- [ ] On a Basius safe past `staking_threshold_period`, observe `Updated mechs' information: ...` (non-empty) replacing the empty-list loop; a `MechMarketplace.request(...)` tx settles; `mapRequestCounts` increments on-chain at the activity checker.
- [ ] Optimus is unaffected today (still on old regime). When Optimus migrates to the new regime AND its priority mech has been bootstrapped with one delivery, the same flow should work for it without further yaml changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)