### PR TITLE
fix(basius,optimus): remove standalone mech_interact_abci stanzas crashing Pearl deploys

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,10 +25,10 @@
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
-        "agent/valory/optimus/0.1.0": "bafybeihpghd65qeiepn5e4r4btqprghv44qgssoqtw26gwdch4bmlpnbfq",
-        "agent/valory/basius/0.1.0": "bafybeibdbc374femx4tfusgpjoncupng7iklqloiuyayb3irjazpnlunmi",
-        "service/valory/optimus/0.1.0": "bafybeiacgh74i7yz2rli2lkqaskd4fx5323ukgkdqth6lgpkyw5gayilj4",
-        "service/valory/basius/0.1.0": "bafybeiaxwi4vmgdutut3acfzudqahveck3alk54frx2xjsx3tranwavnfy"
+        "agent/valory/optimus/0.1.0": "bafybeidz5eak46gw4dyn6nwqf6e5kal4pj47hzn4aphiel7wdqmv6cmhli",
+        "agent/valory/basius/0.1.0": "bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq",
+        "service/valory/optimus/0.1.0": "bafybeigjyo22nl622tn5kbntetyr6obbr3rtk2rzfu6zbqh7xaejehanum",
+        "service/valory/basius/0.1.0": "bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -375,10 +375,3 @@ models:
       safe_api_url: ${SAFE_API_URL:str:https://rpc-gate.autonolas.tech/safe/tx-service}
       safe_api_chain_slugs: ${SAFE_API_CHAIN_SLUGS:str:{"optimism":"oeth","base":"base"}}
       mode_native_explorer_url: ${MODE_NATIVE_EXPLORER_URL:str:https://explorer.mode.network/api}
----
-public_id: valory/mech_interact_abci:0.1.0
-type: skill
-models:
-  mechs_subgraph:
-    args:
-      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -375,10 +375,3 @@ models:
       safe_api_url: ${SAFE_API_URL:str:https://rpc-gate.autonolas.tech/safe/tx-service}
       safe_api_chain_slugs: ${SAFE_API_CHAIN_SLUGS:str:{"optimism":"oeth","base":"base"}}
       mode_native_explorer_url: ${MODE_NATIVE_EXPLORER_URL:str:https://explorer.mode.network/api}
----
-public_id: valory/mech_interact_abci:0.1.0
-type: skill
-models:
-  mechs_subgraph:
-    args:
-      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeibdbc374femx4tfusgpjoncupng7iklqloiuyayb3irjazpnlunmi
+agent: valory/basius:0.1.0:bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq
 number_of_agents: 1
 deployment:
   agent:
@@ -157,13 +157,6 @@ models:
       coingecko_server_base_url: ${COINGECKO_SERVER_BASE_URL:str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${COINGECKO_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${GENAI_NETWORK_SELECTOR:str:base}
-  mechs_subgraph:
-    args:
-      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}
----
-public_id: valory/mech_interact_abci:0.1.0
-type: skill
-models:
   mechs_subgraph:
     args:
       url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-base}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeihpghd65qeiepn5e4r4btqprghv44qgssoqtw26gwdch4bmlpnbfq
+agent: valory/optimus:0.1.0:bafybeidz5eak46gw4dyn6nwqf6e5kal4pj47hzn4aphiel7wdqmv6cmhli
 number_of_agents: 1
 deployment:
   agent:
@@ -157,13 +157,6 @@ models:
       coingecko_server_base_url: ${COINGECKO_SERVER_BASE_URL:str:https://api.coingecko.com}
       coingecko_x402_server_base_url: ${COINGECKO_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/coingecko/{chain}}
       network_selector: ${GENAI_NETWORK_SELECTOR:str:optimism}
-  mechs_subgraph:
-    args:
-      url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}
----
-public_id: valory/mech_interact_abci:0.1.0
-type: skill
-models:
   mechs_subgraph:
     args:
       url: ${MECHS_SUBGRAPH_URL:str:https://api.subgraph.autonolas.tech/api/proxy/marketplace-optimism}


### PR DESCRIPTION
## Summary

Reverts the standalone `valory/mech_interact_abci:0.1.0` skill stanzas that #351 added to both basius and optimus (service.yaml + aea-config.yaml). Those stanzas only contained a `mechs_subgraph` model and no `params` block.

Pearl's `try_update_runtime_params` (`olas-operate-app/operate/services/service.py`) iterates every skill override in the service config and unconditionally indexes `override["models"]["params"]["args"][...]`. With no `params` model on the stanza, that raises `KeyError: 'params'` during deploy, before the agent ever boots. After the rc10 release that included #351, Iason's basius deploy failed at this exact point.

The `optimus_abci.mechs_subgraph` override from #350 stays in place — that block sits inside a stanza that already has a real `params` model so it doesn't hit the crash path.

## Why the original wrong-URL bug needs more than just #350

Verified by unzipping the rc10 `agent_runner_macos_arm64` binary that shipped to Iason: its baked `agent/aea-config.yaml` has **zero** `mechs_subgraph` references. The binary was built `2026-06-23 07:32` while #350 merged at `13:48 UTC` the same day, so it pre-dates the override block being added to `optimus/aea-config.yaml`. Pearl correctly translates the service.yaml override into `SKILL_OPTIMUS_ABCI_MODELS_MECHS_SUBGRAPH_ARGS_URL=...marketplace-base` in `deployment/agent.json`, but the binary's aea-config has no matching line to write to and autonomy silently drops the env var. The `mech_interact_abci/skill.yaml` hardcoded `marketplace-gnosis` default is loaded instead, returning no Base mechs.

This means the original empty-mech-list bug is fixed by **#350 plus rebuilding the agent binary from post-#350 source**. The standalone stanzas from #351 are not needed (and break deploys, as above).

Cross-checked against trader: trader's polystrat overrides `mechs_subgraph` under the `trader_abci` composition skill in its `service.yaml`, Pearl emits `SKILL_TRADER_ABCI_MODELS_MECHS_SUBGRAPH_ARGS_URL=...marketplace-polygon`, the override lands on the trader-binary's `aea-config.yaml` line, and the running agent queries the polygon subgraph. Same shape we'll get on basius once the binary is rebuilt.

## Test plan

- [ ] Land this PR and cut a new rc (the new binary build from main will include the `optimus_abci.mechs_subgraph` block from #350)
- [ ] Bump the basius Pearl template to the new rc + new service hash
- [ ] Verify a fresh Pearl basius deploy no longer crashes with `KeyError: 'params'`
- [ ] Verify the agent logs show `Retrieved mechs' information: [<non-empty>]` after the first `MechInformationRound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)