### PR TITLE
fix(optimus): repoint priority mech to service 195 + tool to prediction-offline

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,9 +25,9 @@
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
-        "agent/valory/optimus/0.1.0": "bafybeidz5eak46gw4dyn6nwqf6e5kal4pj47hzn4aphiel7wdqmv6cmhli",
+        "agent/valory/optimus/0.1.0": "bafybeie6xn3kpgk3tortldq3s3dekzhldfrzukf2hz3wdcj66wdzaoucm4",
         "agent/valory/basius/0.1.0": "bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq",
-        "service/valory/optimus/0.1.0": "bafybeigjyo22nl622tn5kbntetyr6obbr3rtk2rzfu6zbqh7xaejehanum",
+        "service/valory/optimus/0.1.0": "bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye",
         "service/valory/basius/0.1.0": "bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama"
     },
     "third_party": {

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -323,19 +323,19 @@ models:
       staking_activity_checker_contract_address: ${str:0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68}
       staking_threshold_period: ${int:5}
       activity_target: ${ACTIVITY_TARGET:int:1}
-      mech_tool: ${MECH_TOOL:str:openai-gpt-4o-2024-08-06}
+      mech_tool: ${MECH_TOOL:str:prediction-offline}
       mech_request_prompt: ${MECH_REQUEST_PROMPT:str:Optimus staking activity request.}
       multisend_batch_size: ${MECH_MULTISEND_BATCH_SIZE:int:1}
-      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x650C77F49cFa69e2AC1990A6B4585C322B012D0d}
+      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E}
       ipfs_address: ${MECH_IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}
       mech_chain_id: ${MECH_CHAIN_ID:str:optimism}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x4200000000000000000000000000000000000006}
       mech_interaction_sleep_time: ${MECH_INTERACTION_SLEEP_TIME:int:10}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x650C77F49cFa69e2AC1990A6B4585C322B012D0d","priority_mech_service_id":194,"response_timeout":300,"use_dynamic_mech_selection":false}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E","priority_mech_service_id":195,"response_timeout":300,"use_dynamic_mech_selection":false}}
       agent_registry_address: ${MECH_AGENT_REGISTRY_ADDRESS:str:0x0000000000000000000000000000000000000000}
       use_acn_for_delivers: ${USE_ACN_FOR_DELIVERS:bool:false}
-      valid_mechs: ${VALID_MECHS:list:["0x650C77F49cFa69e2AC1990A6B4585C322B012D0d"]}
+      valid_mechs: ${VALID_MECHS:list:["0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E"]}
       penalize_mech_time_window: ${MECH_PENALIZE_TIME_WINDOW:int:1800}
       deliveries_lookback_days: ${MECH_DELIVERIES_LOOKBACK_DAYS:int:30}
       store_path: ${STORE_PATH:str:/data}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeidz5eak46gw4dyn6nwqf6e5kal4pj47hzn4aphiel7wdqmv6cmhli
+agent: valory/optimus:0.1.0:bafybeie6xn3kpgk3tortldq3s3dekzhldfrzukf2hz3wdcj66wdzaoucm4
 number_of_agents: 1
 deployment:
   agent:
@@ -82,19 +82,19 @@ models:
       staking_activity_checker_contract_address: ${ACTIVITY_CHECKER_CONTRACT_ADDRESS:str:0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68}
       staking_threshold_period: ${STAKING_THRESHOLD_PERIOD:int:5}
       activity_target: ${ACTIVITY_TARGET:int:1}
-      mech_tool: ${MECH_TOOL:str:openai-gpt-4o-2024-08-06}
+      mech_tool: ${MECH_TOOL:str:prediction-offline}
       mech_request_prompt: ${MECH_REQUEST_PROMPT:str:Optimus staking activity request.}
       multisend_batch_size: ${MECH_MULTISEND_BATCH_SIZE:int:1}
-      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x650C77F49cFa69e2AC1990A6B4585C322B012D0d}
+      mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E}
       ipfs_address: ${MECH_IPFS_ADDRESS:str:https://gateway.autonolas.tech/ipfs/}
       mech_chain_id: ${MECH_CHAIN_ID:str:optimism}
       mech_wrapped_native_token_address: ${MECH_WRAPPED_NATIVE_TOKEN_ADDRESS:str:0x4200000000000000000000000000000000000006}
       mech_interaction_sleep_time: ${MECH_INTERACTION_SLEEP_TIME:int:10}
       use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x650C77F49cFa69e2AC1990A6B4585C322B012D0d","priority_mech_service_id":194,"response_timeout":300,"use_dynamic_mech_selection":false}}
+      mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461","priority_mech_address":"0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E","priority_mech_service_id":195,"response_timeout":300,"use_dynamic_mech_selection":false}}
       agent_registry_address: ${MECH_AGENT_REGISTRY_ADDRESS:str:0x0000000000000000000000000000000000000000}
       use_acn_for_delivers: ${USE_ACN_FOR_DELIVERS:bool:false}
-      valid_mechs: ${VALID_MECHS:list:["0x650C77F49cFa69e2AC1990A6B4585C322B012D0d"]}
+      valid_mechs: ${VALID_MECHS:list:["0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E"]}
       penalize_mech_time_window: ${MECH_PENALIZE_TIME_WINDOW:int:1800}
       deliveries_lookback_days: ${MECH_DELIVERIES_LOOKBACK_DAYS:int:30}
       store_path: ${STORE_PATH:str:/data/}


### PR DESCRIPTION
## Summary

Repoints optimus at the freshly-deployed Optimism mech (service 195) and switches the default mech tool to `prediction-offline`.

## Why

The previous priority mech `0x650C77F4...d0d` (service id 194) was a contract-only Optimism deployment with no Propel backend behind it. Whoever set it up registered the agent instance using a locally generated EOA rather than a Propel-minted key — and Propel's secret-controller mints keys end-to-end inside its vault and rejects external private keys, so that EOA couldn't be imported. Net result: zero deliveries on mech 194 forever, and since the agent's `mech_information` subgraph query filters on `service_: {totalDeliveries_gt: 0}`, the agent never discovered it. Pearl optimus logs `Retrieved mechs' information: []` and `Failed to fetch mech information for the marketplace.` on loop.

A fresh service was minted on Optimism (id 195) wired correctly from step 1 — Propel key as agent instance, our own service-owner Safe — and the corresponding Propel deployment lands in [valory-xyz/agent-deployments#299](https://github.com/valory-xyz/agent-deployments/pull/299).

## Changes

`aea-config.yaml` and `service.yaml` defaults updated in lockstep:

| Field | Old | New |
|---|---|---|
| `priority_mech_service_id` | `194` | `195` |
| `priority_mech_address` / `mech_contract_address` / `valid_mechs` | `0x650C77F49cFa69e2AC1990A6B4585C322B012D0d` | `0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E` |
| `mech_tool` | `openai-gpt-4o-2024-08-06` | `prediction-offline` |

`mech_marketplace_address` is unchanged (`0x46C0D07F...5020`, same marketplace contract serves both mechs).

`packages.json` hashes refreshed via `autonomy packages lock` and pushed to the IPFS registry via `autonomy push-all`. New agent hash `bafybeie6xn3kpgk3tortldq3s3dekzhldfrzukf2hz3wdcj66wdzaoucm4`, new service hash `bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye`.

## On the tool change

The `openai-gpt-4o-2024-08-06` tool name is served by `valory/openai_request`, which was removed from the mech main repo (commit `978b1948`) and is no longer bundled as a custom by any current mech-predict service hash. Pinning to its historical hash fails the agent-deployments hash-check CI.

`prediction-offline` is served by `valory/prediction_request` which IS bundled, and uses `gpt-4o-2024-08-06` as the underlying OpenAI model. Functionally equivalent for the optimus staking-KPI use case (the agent fires one periodic request to bump the activity counter; response content isn't consumed).

## Test plan

- [ ] CI green on this PR
- [ ] Once agent-deployments#299 deploys the new mech backend on Propel, observe `Retrieved mechs' information: [<non-empty>]` replacing the empty-list loop
- [ ] First mech request settles, `mapRequestCounts` increments on the activity checker for the staking KPI
- [ ] Follow-up: cut a Pearl rc that ships this optimus agent + service hash so Pearl-deployed optimus users pick up the repoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)