### PR TITLE
fix(funds_manager): track USDC requirement on safe for mech payments

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,10 +25,10 @@
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
         "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
-        "agent/valory/optimus/0.1.0": "bafybeie6xn3kpgk3tortldq3s3dekzhldfrzukf2hz3wdcj66wdzaoucm4",
-        "agent/valory/basius/0.1.0": "bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq",
-        "service/valory/optimus/0.1.0": "bafybeieh7ipqea66s2p3km52fwnkeosileg5rqwecmon4azuohwbxvowye",
-        "service/valory/basius/0.1.0": "bafybeicp74th4cghtcnk4nvdhfnxwodwuuv3vrisk6ijetf7ausk7xsama"
+        "agent/valory/optimus/0.1.0": "bafybeihyp7ae5tefto2jci2tksszoyjya7ls3hu3yyuyfbaahuqbkblbzm",
+        "agent/valory/basius/0.1.0": "bafybeiazct6l36ckwpsyjmgvqg3jddjcynx7epa5slefiuv2tstid3qqji",
+        "service/valory/optimus/0.1.0": "bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy",
+        "service/valory/basius/0.1.0": "bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -192,9 +192,9 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
-      rpc_urls: ${dict:{"optimism":"https://mainnet.optimism.io"}}
-      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
+      fund_requirements: ${dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913":{"topup":700000,"threshold":350000}}}}}
+      rpc_urls: ${dict:{"base":"https://mainnet.base.org"}}
+      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"base":"0x0000000000000000000000000000000000000000"}}
 ---
 public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -192,7 +192,7 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
+      fund_requirements: ${dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85":{"topup":700000,"threshold":350000}}}}}
       rpc_urls: ${dict:{"optimism":"https://mainnet.optimism.io"}}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"optimism":"0x0000000000000000000000000000000000000000"}}
 ---

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeierqtcvug7p4g4w6hdzl3ja2avvsdsbnj2zskyzztmbzwuvaanwbq
+agent: valory/basius:0.1.0:bafybeiazct6l36ckwpsyjmgvqg3jddjcynx7epa5slefiuv2tstid3qqji
 number_of_agents: 1
 deployment:
   agent:
@@ -236,7 +236,7 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${FUND_REQUIREMENTS:dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
+      fund_requirements: ${FUND_REQUIREMENTS:dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913":{"topup":700000,"threshold":350000}}}}}
       rpc_urls:
         base: ${BASE_LEDGER_RPC:str:https://mainnet.base.org}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"base":"0x0000000000000000000000000000000000000000"}}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeie6xn3kpgk3tortldq3s3dekzhldfrzukf2hz3wdcj66wdzaoucm4
+agent: valory/optimus:0.1.0:bafybeihyp7ae5tefto2jci2tksszoyjya7ls3hu3yyuyfbaahuqbkblbzm
 number_of_agents: 1
 deployment:
   agent:
@@ -236,7 +236,7 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${FUND_REQUIREMENTS:dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0}}}}}
+      fund_requirements: ${FUND_REQUIREMENTS:dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85":{"topup":700000,"threshold":350000}}}}}
       rpc_urls:
         optimism: ${OPTIMISM_LEDGER_RPC:str:https://mainnet.optimism.io}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"optimism":"0x0000000000000000000000000000000000000000"}}


### PR DESCRIPTION
## Summary

Adds a USDC entry to the \`funds_manager\` \`fund_requirements\` default for both optimus (Optimism) and basius (Base) so the agent's \`/funds-status\` endpoint surfaces a USDC deficit on the safe. Mech payments settle in USDC (\`FixedPriceTokenUSDC\` mech flavour on both Optimism mech 195 and Base mech 112), but the YAML defaults only tracked native ETH. Pearl's onboarding template declared a USDC requirement but that value never reached the agent because Pearl doesn't emit a \`FUND_REQUIREMENTS\` env var.

## Why this matters

Without this, the only signal the agent has that USDC is missing is the reactive warning in \`mech_interact_abci.behaviours.request._ensure_available_balance\` at mech-request time. That signal doesn't flow back into \`/funds-status\`, so Pearl polls \`/funds-status\` and gets only an ETH view. The USDC shortage stays invisible to anything downstream of the agent's endpoint and the agent silently fails to deliver mech requests once the safe runs out.

Reproduced on optimus mech 195 (safe \`0xc449F6b1c380Eee6dec31F79acE512Ec3931beA2\`): on-chain USDC balance was 0, agent logged \"The balance is not enough to pay for the mech's price. Please refill the safe with at least 0.01 0x0b2C63... tokens.\" repeatedly, no mech request fired, KPI never ticked.

## Sizing

Threshold/topup sized for ~1 week of mech requests at 5 reqs/day, 0.01 USDC per request:

| field | wei | USDC |
|---|---|---|
| threshold | \`350000\` | 0.35 (1 week minimum) |
| topup     | \`700000\` | 0.70 (2 weeks ceiling) |

Both values are intentionally tiny since mech requests are cheap. Easy to bump later.

## Side fix on basius aea-config

The basius \`aea-config.yaml\` funds_manager default declared \`\"optimism\"\` as the chain (inherited from the optimus copy), which is incoherent for a base-only service. The service.yaml override masks it in production, but the aea-config default is what local-dev fetches use. Repointed to \`\"base\"\` with the base rpc and base USDC alongside the funds_manager change.

## Files changed

- \`packages/valory/agents/optimus/aea-config.yaml\` — add Optimism USDC under safe
- \`packages/valory/services/optimus/service.yaml\` — same, env-overridable
- \`packages/valory/agents/basius/aea-config.yaml\` — repoint default chain to base, add Base USDC under safe
- \`packages/valory/services/basius/service.yaml\` — add Base USDC under safe

## New hashes

- optimus agent: \`bafybeihyp7ae5tefto2jci2tksszoyjya7ls3hu3yyuyfbaahuqbkblbzm\`
- optimus service: \`bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy\`
- basius agent: \`bafybeiazct6l36ckwpsyjmgvqg3jddjcynx7epa5slefiuv2tstid3qqji\`
- basius service: \`bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru\`

## Test plan

- [x] \`autonomy packages lock\` succeeds with updated hashes
- [x] \`autonomy push-all\` published all four to IPFS
- [ ] Pearl bumps \`OPTIMUS_TEMPLATE_RELEASE.hash\` / \`BASIUS_TEMPLATE_RELEASE.hash\` to the new service hashes
- [ ] Confirm \`/funds-status\` on a running agent reports a USDC deficit when the safe is empty
- [ ] Confirm a freshly-funded safe (with 1 USDC) gets through \`_ensure_available_balance\` and fires the mech request

## Follow-up

Pearl middleware ideally should also push \`FUND_REQUIREMENTS\` as an env var so the template's per-deployment values can override the service.yaml default per user. Out of scope here, but worth a separate operate-app issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)