### PR TITLE
fix: reserve mech fees from investable balance + velodrome unstake tx bytes pass-through

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,12 +23,12 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4",
-        "skill/valory/optimus_abci/0.1.0": "bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm",
-        "agent/valory/optimus/0.1.0": "bafybeihyp7ae5tefto2jci2tksszoyjya7ls3hu3yyuyfbaahuqbkblbzm",
-        "agent/valory/basius/0.1.0": "bafybeiazct6l36ckwpsyjmgvqg3jddjcynx7epa5slefiuv2tstid3qqji",
-        "service/valory/optimus/0.1.0": "bafybeih52axldd5orb2pjavmxb6lxnke4tdggrlqotyk6oam6ipa5zeiyy",
-        "service/valory/basius/0.1.0": "bafybeieyje3avjjhlk2qtxswu7uvukaqnsvzmlfvgy3qzarxyv3cd6viru"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey",
+        "skill/valory/optimus_abci/0.1.0": "bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi",
+        "agent/valory/optimus/0.1.0": "bafybeiaxnitc34mmg6ud324xbwkcp2le4snmtwne6uzvwvjv3gwnb3ar24",
+        "agent/valory/basius/0.1.0": "bafybeigadtqiy2najenkyu7tvtaye3dafq4vr6dzgkpzasuaalx4lihh2u",
+        "service/valory/optimus/0.1.0": "bafybeigv2p3m2zo2qp7ujybvteqcqigfwfu76qdivgopycnk3b235vu4me",
+        "service/valory/basius/0.1.0": "bafybeicdzj4nckxtnfynafmamlugyfryunjkr23ruh4e6jpyzl677r7uze"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,12 +23,12 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde",
-        "skill/valory/optimus_abci/0.1.0": "bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e",
-        "agent/valory/optimus/0.1.0": "bafybeifww4wo7pakuu4fvnnrpvdjpv3zhobw6d65jpa2kkr3jco4chqyfi",
-        "agent/valory/basius/0.1.0": "bafybeiehmd5sibsxxpyolr5gwhxxnndutcxqhjvygh2qsvk7pvd3ohadnq",
-        "service/valory/optimus/0.1.0": "bafybeic4zkkslpqy5ybetxkvth3cw3deb2q7sqa3a36lrkptr5nqhgne5a",
-        "service/valory/basius/0.1.0": "bafybeicqvpdgj6cyqefhastaijq6pvaydbhdpptw4rzmiznpabbxdk4cdy"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa",
+        "skill/valory/optimus_abci/0.1.0": "bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza",
+        "agent/valory/optimus/0.1.0": "bafybeiccapzudezwa63svwkiwp7qtu5ishwd4e52lzzokfkxskwtvaymle",
+        "agent/valory/basius/0.1.0": "bafybeib5myggxbdph7aqhsfyfpcxpwyaywhxwdrwf74ljknf2s7mgcj3qa",
+        "service/valory/optimus/0.1.0": "bafybeihsahwqfuisc767r7xglybj2wzwsqgrzdq6anbfilp4aeufhumzg4",
+        "service/valory/basius/0.1.0": "bafybeie5fuhjjvudn6qe3olrcc7w3akpigr4emq4ui53sykkgzc5qbonr4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,12 +23,12 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa",
-        "skill/valory/optimus_abci/0.1.0": "bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza",
-        "agent/valory/optimus/0.1.0": "bafybeiccapzudezwa63svwkiwp7qtu5ishwd4e52lzzokfkxskwtvaymle",
-        "agent/valory/basius/0.1.0": "bafybeib5myggxbdph7aqhsfyfpcxpwyaywhxwdrwf74ljknf2s7mgcj3qa",
-        "service/valory/optimus/0.1.0": "bafybeihsahwqfuisc767r7xglybj2wzwsqgrzdq6anbfilp4aeufhumzg4",
-        "service/valory/basius/0.1.0": "bafybeie5fuhjjvudn6qe3olrcc7w3akpigr4emq4ui53sykkgzc5qbonr4"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeidriubtvnzbstj2ydczozj3xehc6e5dknp6dlma5urri43vrnqpnq",
+        "skill/valory/optimus_abci/0.1.0": "bafybeid43lif2iegegesbnglc65pondbvadmxaftk6xvgqoer4djpobyba",
+        "agent/valory/optimus/0.1.0": "bafybeiesti3733fzubsk2wexse4pwrdovakbmrconnbvm5txqjutx4ubie",
+        "agent/valory/basius/0.1.0": "bafybeidko67ekquimubc2un2zt3jkyokdinfa4wphuh7yfe5biypbh6bpe",
+        "service/valory/optimus/0.1.0": "bafybeiadfyrrbypfbnfzg4v3fx2yxex6gcj5eqlknsnqfsz2vvp674o5su",
+        "service/valory/basius/0.1.0": "bafybeiax2dkm6sw2j2scyd5zjsgufpgvsxtjow6clguz6qrgsizrpb7uqy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,12 +23,12 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeicqjs5styv3qubfd7askc6nnd2hrwqlawd6b7rvzyvp2ycbenensm",
         "contract/valory/balancer_queries/0.1.0": "bafybeieopocjnprwfazmacrgr4n6up2p2warpq7seiwhocb5f2uy4mrmrq",
         "contract/valory/mech_activity/0.1.0": "bafybeigycloyodu27j763cft673aookhzqxnn2sf2cdccoh4hvb5zxcq3i",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey",
-        "skill/valory/optimus_abci/0.1.0": "bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi",
-        "agent/valory/optimus/0.1.0": "bafybeiaxnitc34mmg6ud324xbwkcp2le4snmtwne6uzvwvjv3gwnb3ar24",
-        "agent/valory/basius/0.1.0": "bafybeigadtqiy2najenkyu7tvtaye3dafq4vr6dzgkpzasuaalx4lihh2u",
-        "service/valory/optimus/0.1.0": "bafybeigv2p3m2zo2qp7ujybvteqcqigfwfu76qdivgopycnk3b235vu4me",
-        "service/valory/basius/0.1.0": "bafybeicdzj4nckxtnfynafmamlugyfryunjkr23ruh4e6jpyzl677r7uze"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde",
+        "skill/valory/optimus_abci/0.1.0": "bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e",
+        "agent/valory/optimus/0.1.0": "bafybeifww4wo7pakuu4fvnnrpvdjpv3zhobw6d65jpa2kkr3jco4chqyfi",
+        "agent/valory/basius/0.1.0": "bafybeiehmd5sibsxxpyolr5gwhxxnndutcxqhjvygh2qsvk7pvd3ohadnq",
+        "service/valory/optimus/0.1.0": "bafybeic4zkkslpqy5ybetxkvth3cw3deb2q7sqa3a36lrkptr5nqhgne5a",
+        "service/valory/basius/0.1.0": "bafybeicqvpdgj6cyqefhastaijq6pvaydbhdpptw4rzmiznpabbxdk4cdy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
+- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e
+- valory/optimus_abci:0.1.0:bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4
+- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm
+- valory/optimus_abci:0.1.0:bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
@@ -192,7 +192,7 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913":{"topup":700000,"threshold":350000}}}}}
+      fund_requirements: ${dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":100000000000000,"threshold":350}}}}}
       rpc_urls: ${dict:{"base":"https://mainnet.base.org"}}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"base":"0x0000000000000000000000000000000000000000"}}
 ---
@@ -352,6 +352,7 @@ models:
       balancer_graphql_endpoints: ${str:{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["optimism"]}
       staking_chain: ${str:optimism}
+      fund_requirements: ${dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":100000000000000,"threshold":350}}}}}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:str:{"bafybeib2szveecjhwlu5aeww5umtso5sm4btogsrjuqg4tk5uormjmsppi":"max_apr_selection","bafybeiaktss4rvsyiqg43yauc3aj5mq3ztysgqopc2dvxkslswj25kdtcm":"balancer_pools_search","bafybeiglbwfrhxbgqyyg6oniwur2x6sswmi5ed55crzvrhr3o7p5x3kmne":"uniswap_pools_search","bafybeifiotxje5ndkdj673oo2uxfpj76fd32qjp7tpxbbdmidbzcqna23a":"asset_lending","bafybeielyh7i7qjm54h3tne4gcgiuqutqavmczoqc6bguupqnnjzwjtvm4":"velodrome_pools_search"}}
       strategies_kwargs: ${str:{"merkl_pools_search":{"balancer_graphql_endpoints":{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"},"merkl_fetch_campaign_args":{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}},"uniswap_pools_search":{"graphql_endpoints":{"optimism":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5","base":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/GqzP4Xaehti8KSfQmv3ZctFSjnSUYZ4En5NRsiTbvZpz"}},"balancer_pools_search":{"graphql_endpoint":"https://api-v3.balancer.fi/"},"velodrome_pools_search":{"graphql_endpoint":"https://gateway.thegraph.com/api/b8e4cf1b314c67d2a0109325046a7464/subgraphs/id/7tA4PY1VmbycJeoVtn2mjQK4NbozgwTuZgrxDTxzEDL1"},"asset_lending":{"endpoint":"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/v2Aggregators","lending_asset":"0x4200000000000000000000000000000000000006"}}}
       available_protocols: ${list:["VELODROME"]}

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
+- valory/liquidity_trader_abci:0.1.0:bafybeidriubtvnzbstj2ydczozj3xehc6e5dknp6dlma5urri43vrnqpnq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza
+- valory/optimus_abci:0.1.0:bafybeid43lif2iegegesbnglc65pondbvadmxaftk6xvgqoer4djpobyba
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
+- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi
+- valory/optimus_abci:0.1.0:bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
+- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e
+- valory/optimus_abci:0.1.0:bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4
+- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeihoneiqnskjd7eskcngaauypulhoqh5apvklrkbz6irpnt2556qnm
+- valory/optimus_abci:0.1.0:bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
@@ -352,6 +352,7 @@ models:
       balancer_graphql_endpoints: ${str:{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["optimism"]}
       staking_chain: ${str:optimism}
+      fund_requirements: ${dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85":{"topup":700000,"threshold":350000}}}}}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:str:{"bafybeib2szveecjhwlu5aeww5umtso5sm4btogsrjuqg4tk5uormjmsppi":"max_apr_selection","bafybeiaktss4rvsyiqg43yauc3aj5mq3ztysgqopc2dvxkslswj25kdtcm":"balancer_pools_search","bafybeiglbwfrhxbgqyyg6oniwur2x6sswmi5ed55crzvrhr3o7p5x3kmne":"uniswap_pools_search","bafybeifiotxje5ndkdj673oo2uxfpj76fd32qjp7tpxbbdmidbzcqna23a":"asset_lending","bafybeielyh7i7qjm54h3tne4gcgiuqutqavmczoqc6bguupqnnjzwjtvm4":"velodrome_pools_search"}}
       strategies_kwargs: ${str:{"merkl_pools_search":{"balancer_graphql_endpoints":{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"},"merkl_fetch_campaign_args":{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}},"uniswap_pools_search":{"graphql_endpoints":{"optimism":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5","base":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/GqzP4Xaehti8KSfQmv3ZctFSjnSUYZ4En5NRsiTbvZpz"}},"balancer_pools_search":{"graphql_endpoint":"https://api-v3.balancer.fi/"},"velodrome_pools_search":{"graphql_endpoint":"https://gateway.thegraph.com/api/b8e4cf1b314c67d2a0109325046a7464/subgraphs/id/7tA4PY1VmbycJeoVtn2mjQK4NbozgwTuZgrxDTxzEDL1"},"asset_lending":{"endpoint":"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/v2Aggregators","lending_asset":"0x4200000000000000000000000000000000000006"}}}
       available_protocols: ${list:["VELODROME"]}

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
+- valory/liquidity_trader_abci:0.1.0:bafybeidriubtvnzbstj2ydczozj3xehc6e5dknp6dlma5urri43vrnqpnq
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeibblze7sbrya54zilbpi6dkjvxd5uod76vshwxi4gafrhrq74rhza
+- valory/optimus_abci:0.1.0:bafybeid43lif2iegegesbnglc65pondbvadmxaftk6xvgqoer4djpobyba
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -68,9 +68,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
-- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
+- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
-- valory/optimus_abci:0.1.0:bafybeighy5be2v2czqrvqit7kfnj5grmlhqp2wikb2d65hmwvx3jak47zi
+- valory/optimus_abci:0.1.0:bafybeihzmdil44ixvorq37cpdmijeqr7tiaxsu3etyv4odbv2b7vsnan7e
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeiehmd5sibsxxpyolr5gwhxxnndutcxqhjvygh2qsvk7pvd3ohadnq
+agent: valory/basius:0.1.0:bafybeib5myggxbdph7aqhsfyfpcxpwyaywhxwdrwf74ljknf2s7mgcj3qa
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeib5myggxbdph7aqhsfyfpcxpwyaywhxwdrwf74ljknf2s7mgcj3qa
+agent: valory/basius:0.1.0:bafybeidko67ekquimubc2un2zt3jkyokdinfa4wphuh7yfe5biypbh6bpe
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeigadtqiy2najenkyu7tvtaye3dafq4vr6dzgkpzasuaalx4lihh2u
+agent: valory/basius:0.1.0:bafybeiehmd5sibsxxpyolr5gwhxxnndutcxqhjvygh2qsvk7pvd3ohadnq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeiazct6l36ckwpsyjmgvqg3jddjcynx7epa5slefiuv2tstid3qqji
+agent: valory/basius:0.1.0:bafybeigadtqiy2najenkyu7tvtaye3dafq4vr6dzgkpzasuaalx4lihh2u
 number_of_agents: 1
 deployment:
   agent:
@@ -114,6 +114,7 @@ models:
       allowed_chains: ${ALLOWED_CHAINS:list:["base","optimism","mode"]}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["base"]}
       staking_chain: ${STAKING_CHAIN:str:base}
+      fund_requirements: ${FUND_REQUIREMENTS:dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":100000000000000,"threshold":350}}}}}
       initial_assets: ${INITIAL_ASSETS:str:{"base":{"0x0000000000000000000000000000000000000000":"ETH","0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913":"USDC"}}}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:str:{"bafybeib2szveecjhwlu5aeww5umtso5sm4btogsrjuqg4tk5uormjmsppi":"max_apr_selection","bafybeiaktss4rvsyiqg43yauc3aj5mq3ztysgqopc2dvxkslswj25kdtcm":"balancer_pools_search","bafybeiglbwfrhxbgqyyg6oniwur2x6sswmi5ed55crzvrhr3o7p5x3kmne":"uniswap_pools_search","bafybeifiotxje5ndkdj673oo2uxfpj76fd32qjp7tpxbbdmidbzcqna23a":"asset_lending","bafybeielyh7i7qjm54h3tne4gcgiuqutqavmczoqc6bguupqnnjzwjtvm4":"velodrome_pools_search"}}
       strategies_kwargs: ${STRATEGIES_KWARGS:str:{"merkl_pools_search":{"balancer_graphql_endpoints":{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"},"merkl_fetch_campaign_args":{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}},"uniswap_pools_search":{"graphql_endpoints":{"optimism":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5","base":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5"}},"balancer_pools_search":{"graphql_endpoint":"https://api-v3.balancer.fi/"},"velodrome_pools_search":{"graphql_endpoint":"https://gateway.thegraph.com/api/b8e4cf1b314c67d2a0109325046a7464/subgraphs/id/A4Y1A82YhSLTn998BVVELC8eWzhi992k4ZitByvssxqA"},"asset_lending":{"endpoint":"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/v2Aggregators","lending_asset":"0x4200000000000000000000000000000000000006"}}}
@@ -236,7 +237,7 @@ type: skill
 models:
   params:
     args:
-      fund_requirements: ${FUND_REQUIREMENTS:dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913":{"topup":700000,"threshold":350000}}}}}
+      fund_requirements: ${FUND_REQUIREMENTS:dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":100000000000000,"threshold":350}}}}}
       rpc_urls:
         base: ${BASE_LEDGER_RPC:str:https://mainnet.base.org}
       safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"base":"0x0000000000000000000000000000000000000000"}}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeihyp7ae5tefto2jci2tksszoyjya7ls3hu3yyuyfbaahuqbkblbzm
+agent: valory/optimus:0.1.0:bafybeiaxnitc34mmg6ud324xbwkcp2le4snmtwne6uzvwvjv3gwnb3ar24
 number_of_agents: 1
 deployment:
   agent:
@@ -114,6 +114,7 @@ models:
       allowed_chains: ${ALLOWED_CHAINS:list:["base","optimism","mode"]}
       target_investment_chains: ${TARGET_INVESTMENT_CHAINS:list:["base","optimism","mode"]}
       staking_chain: ${STAKING_CHAIN:str:""}
+      fund_requirements: ${FUND_REQUIREMENTS:dict:{"optimism":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":200000000000000,"threshold":100000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":0,"threshold":0},"0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85":{"topup":700000,"threshold":350000}}}}}
       initial_assets: ${INITIAL_ASSETS:str:{"mode":{"0x0000000000000000000000000000000000000000":"ETH","0xd988097fb8612cc24eeC14542bC03424c656005f":"USDC"}}}
       file_hash_to_strategies: ${FILE_HASH_TO_STRATEGIES:str:{"bafybeib2szveecjhwlu5aeww5umtso5sm4btogsrjuqg4tk5uormjmsppi":"max_apr_selection","bafybeiaktss4rvsyiqg43yauc3aj5mq3ztysgqopc2dvxkslswj25kdtcm":"balancer_pools_search","bafybeiglbwfrhxbgqyyg6oniwur2x6sswmi5ed55crzvrhr3o7p5x3kmne":"uniswap_pools_search","bafybeifiotxje5ndkdj673oo2uxfpj76fd32qjp7tpxbbdmidbzcqna23a":"asset_lending","bafybeielyh7i7qjm54h3tne4gcgiuqutqavmczoqc6bguupqnnjzwjtvm4":"velodrome_pools_search"}}
       strategies_kwargs: ${STRATEGIES_KWARGS:str:{"merkl_pools_search":{"balancer_graphql_endpoints":{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"},"merkl_fetch_campaign_args":{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}},"uniswap_pools_search":{"graphql_endpoints":{"optimism":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5","base":"https://gateway.thegraph.com/api/575c6d9779719bc1ced85444c98441be/subgraphs/id/7SVwgBfXoWmiK6x1NF1VEo1szkeWLniqWN1oYsX3UMb5"}},"balancer_pools_search":{"graphql_endpoint":"https://api-v3.balancer.fi/"},"velodrome_pools_search":{"graphql_endpoint":"https://gateway.thegraph.com/api/b8e4cf1b314c67d2a0109325046a7464/subgraphs/id/A4Y1A82YhSLTn998BVVELC8eWzhi992k4ZitByvssxqA"},"asset_lending":{"endpoint":"https://us-central1-stu-dashboard-a0ba2.cloudfunctions.net/v2Aggregators","lending_asset":"0x4200000000000000000000000000000000000006"}}}

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeifww4wo7pakuu4fvnnrpvdjpv3zhobw6d65jpa2kkr3jco4chqyfi
+agent: valory/optimus:0.1.0:bafybeiccapzudezwa63svwkiwp7qtu5ishwd4e52lzzokfkxskwtvaymle
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeiaxnitc34mmg6ud324xbwkcp2le4snmtwne6uzvwvjv3gwnb3ar24
+agent: valory/optimus:0.1.0:bafybeifww4wo7pakuu4fvnnrpvdjpv3zhobw6d65jpa2kkr3jco4chqyfi
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeiccapzudezwa63svwkiwp7qtu5ishwd4e52lzzokfkxskwtvaymle
+agent: valory/optimus:0.1.0:bafybeiesti3733fzubsk2wexse4pwrdovakbmrconnbvm5txqjutx4ubie
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -1229,18 +1229,24 @@ class LiquidityTraderBaseBehaviour(
         :param token: token address; ``ZERO_ADDRESS`` for native.
         :return: reserved amount in wei/smallest unit, 0 if none configured.
         """
-        safe_requirements = self.params.fund_requirements.get(chain, {}).get("safe", {})
-        for address, requirement in safe_requirements.items():
-            if address.lower() == token.lower():
-                try:
-                    return int(requirement.get("topup", 0))
-                except (ValueError, TypeError, AttributeError):
-                    self.context.logger.warning(
-                        f"Malformed fund_requirements safe entry on {chain} "
-                        f"for {token}: {requirement!r}; mech fee reserve disabled."
-                    )
-                    return 0
-        return 0
+        try:
+            safe_requirements = self.params.fund_requirements.get(chain, {}).get(
+                "safe", {}
+            )
+            for address, requirement in safe_requirements.items():
+                if address.lower() != token.lower():
+                    continue
+                topup = int(requirement.get("topup", 0))
+                if topup < 0:
+                    raise ValueError(f"negative topup: {topup}")
+                return topup
+            return 0
+        except (ValueError, TypeError, AttributeError) as e:
+            self.context.logger.warning(
+                f"Malformed fund_requirements on {chain} for {token} ({e}); "
+                "mech fee reserve disabled."
+            )
+            return 0
 
     def _apply_mech_fee_reserve(self, chain: str, token: str, balance: int) -> int:
         """Return ``balance`` minus the mech fee reserve, floored at 0."""

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -1217,6 +1217,40 @@ class LiquidityTraderBaseBehaviour(
 
         return None
 
+    def _get_mech_fee_reserve(self, chain: str, token: str) -> int:
+        """Get the safe-balance portion of ``token`` reserved for mech request fees.
+
+        The reserve is the safe topup declared in ``fund_requirements`` (the
+        same config the funds_manager skill reports to the operator for
+        refills). Reserving exactly the topup keeps the refilled amount out
+        of investments so mech payments can't be invested away.
+
+        :param chain: chain identifier (e.g. ``"base"``).
+        :param token: token address; ``ZERO_ADDRESS`` for native.
+        :return: reserved amount in wei/smallest unit, 0 if none configured.
+        """
+        safe_requirements = self.params.fund_requirements.get(chain, {}).get("safe", {})
+        for address, requirement in safe_requirements.items():
+            if address.lower() == token.lower():
+                try:
+                    return int(requirement.get("topup", 0))
+                except (ValueError, TypeError):
+                    return 0
+        return 0
+
+    def _apply_mech_fee_reserve(self, chain: str, token: str, balance: int) -> int:
+        """Return ``balance`` minus the mech fee reserve, floored at 0."""
+        reserve = self._get_mech_fee_reserve(chain, token)
+        if reserve <= 0:
+            return balance
+        spendable = max(0, balance - reserve)
+        if spendable != balance:
+            self.context.logger.info(
+                f"Mech fee reserve on {chain} for {token}: "
+                f"balance={balance}, reserved={reserve}, spendable={spendable}"
+            )
+        return spendable
+
     def _get_token_decimals(
         self, chain: str, asset_address: str
     ) -> Generator[None, None, Optional[int]]:

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/base.py
@@ -1234,7 +1234,11 @@ class LiquidityTraderBaseBehaviour(
             if address.lower() == token.lower():
                 try:
                     return int(requirement.get("topup", 0))
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, AttributeError):
+                    self.context.logger.warning(
+                        f"Malformed fund_requirements safe entry on {chain} "
+                        f"for {token}: {requirement!r}; mech fee reserve disabled."
+                    )
                     return 0
         return 0
 

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
@@ -1894,13 +1894,13 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
 
         raw_balance = token_balance
         token_balance = self._apply_mech_fee_reserve(chain, asset, token_balance)
-        if token_balance == 0 and raw_balance > 0:
+        amount = int(min(token_balance * relative_funds_percentage, token_balance))
+        if amount == 0 and token_balance < raw_balance:
             self.context.logger.warning(
-                f"Balance of {asset} on {chain} is fully reserved for mech fees; "
-                "skipping deposit."
+                f"Deposit amount for {asset} on {chain} is zero after the "
+                "mech fee reserve; skipping deposit."
             )
             return None, None, None
-        amount = int(min(token_balance * relative_funds_percentage, token_balance))
 
         safe_address = self.params.safe_contract_addresses.get(chain)
         receiver = safe_address

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
@@ -1892,7 +1892,14 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
             self.context.logger.error(f"Could not determine balance for {asset}")
             return None, None, None
 
+        raw_balance = token_balance
         token_balance = self._apply_mech_fee_reserve(chain, asset, token_balance)
+        if token_balance == 0 and raw_balance > 0:
+            self.context.logger.warning(
+                f"Balance of {asset} on {chain} is fully reserved for mech fees; "
+                "skipping deposit."
+            )
+            return None, None, None
         amount = int(min(token_balance * relative_funds_percentage, token_balance))
 
         safe_address = self.params.safe_contract_addresses.get(chain)

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/decision_making.py
@@ -1232,6 +1232,8 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
         # Fetch balances and prices to compute total USD principal slice
         token0_balance = self._get_balance(chain, assets[0], positions) or 0
         token1_balance = self._get_balance(chain, assets[1], positions) or 0
+        token0_balance = self._apply_mech_fee_reserve(chain, assets[0], token0_balance)
+        token1_balance = self._apply_mech_fee_reserve(chain, assets[1], token1_balance)
 
         # Get decimals
         token0_decimals = yield from self._get_token_decimals(chain, assets[0])
@@ -1331,6 +1333,13 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
             if token0_balance is None or token1_balance is None:
                 self.context.logger.error("Balance for one or more tokens is None")
                 return None, None, None
+
+            token0_balance = self._apply_mech_fee_reserve(
+                chain, assets[0], token0_balance
+            )
+            token1_balance = self._apply_mech_fee_reserve(
+                chain, assets[1], token1_balance
+            )
 
             # Calculate max_amounts_in based on whether max_investment_amounts are provided
             if max_investment_amounts:
@@ -1879,6 +1888,11 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
             return None, None, None
 
         token_balance = self._get_balance(chain, asset, positions)
+        if token_balance is None:
+            self.context.logger.error(f"Could not determine balance for {asset}")
+            return None, None, None
+
+        token_balance = self._apply_mech_fee_reserve(chain, asset, token_balance)
         amount = int(min(token_balance * relative_funds_percentage, token_balance))
 
         safe_address = self.params.safe_contract_addresses.get(chain)
@@ -2612,6 +2626,12 @@ class DecisionMakingBehaviour(LiquidityTraderBaseBehaviour):
                 f"Could not determine available amount for {from_token_symbol} on chain {from_chain}"
             )
             return None
+
+        # Withdrawals must sweep everything, including the mech fee reserve.
+        if not investing_paused:
+            available_amount = self._apply_mech_fee_reserve(
+                from_chain, from_token_address, available_amount
+            )
 
         # Calculate the amount to swap based on the available amount and funds percentage
         snapshot_balance = action.get("source_initial_balance")

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
@@ -1380,11 +1380,14 @@ class EvaluateStrategyBehaviour(LiquidityTraderBaseBehaviour):
                     asset_symbol = asset.get("asset_symbol")
                     balance = asset.get("balance", 0)
 
-                    # Skip if no balance or asset is whitelisted
+                    # Skip if no balance or asset is whitelisted. Native ETH is
+                    # never swept: the safe pays mech request fees in native on
+                    # Base, so converting it would break staking KPI requests.
                     if (
                         balance <= 0
                         or asset_address in whitelisted_tokens
                         or asset_address == olas_token_address
+                        or asset_address == ZERO_ADDRESS.lower()
                     ):
                         continue
 
@@ -2488,7 +2491,11 @@ class EvaluateStrategyBehaviour(LiquidityTraderBaseBehaviour):
     def _get_investable_balance(
         self, chain: str, token_address: str, total_balance: int
     ) -> Generator[None, None, int]:
-        """Get the portion of token balance available for investment (total - reserved rewards - airdrop rewards)"""
+        """Get the portion of token balance available for investment (total - mech fee reserve - reserved rewards - airdrop rewards)"""
+
+        total_balance = self._apply_mech_fee_reserve(
+            chain, token_address, total_balance
+        )
 
         # Check if this is a reward token
         reward_addresses = REWARD_TOKEN_ADDRESSES.get(chain, {})

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
@@ -1381,8 +1381,9 @@ class EvaluateStrategyBehaviour(LiquidityTraderBaseBehaviour):
                     balance = asset.get("balance", 0)
 
                     # Skip if no balance or asset is whitelisted. The native
-                    # token is never swept: it is reserved for gas and, where
-                    # the mech charges in native, for mech request fees.
+                    # token is always kept out of the USDC sweep (gas and mech
+                    # request fees); _apply_mech_fee_reserve handles the fee
+                    # reserve separately.
                     if (
                         balance <= 0
                         or asset_address in whitelisted_tokens

--- a/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
+++ b/packages/valory/skills/liquidity_trader_abci/behaviours/evaluate_strategy.py
@@ -1380,9 +1380,9 @@ class EvaluateStrategyBehaviour(LiquidityTraderBaseBehaviour):
                     asset_symbol = asset.get("asset_symbol")
                     balance = asset.get("balance", 0)
 
-                    # Skip if no balance or asset is whitelisted. Native ETH is
-                    # never swept: the safe pays mech request fees in native on
-                    # Base, so converting it would break staking KPI requests.
+                    # Skip if no balance or asset is whitelisted. The native
+                    # token is never swept: it is reserved for gas and, where
+                    # the mech charges in native, for mech request fees.
                     if (
                         balance <= 0
                         or asset_address in whitelisted_tokens

--- a/packages/valory/skills/liquidity_trader_abci/models.py
+++ b/packages/valory/skills/liquidity_trader_abci/models.py
@@ -522,6 +522,12 @@ class Params(BaseParams):
         self.staking_chain: Optional[str] = self._ensure(
             "staking_chain", kwargs, Optional[str]
         )
+        # Same shape as the funds_manager skill's fund_requirements. The safe
+        # topups double as mech-fee reserves: that portion of the safe balance
+        # is excluded from investment so refills aren't invested away.
+        self.fund_requirements: Dict[str, Any] = self._ensure(
+            "fund_requirements", kwargs, Dict[str, Any]
+        )
         self.file_hash_to_strategies = json.loads(
             self._ensure("file_hash_to_strategies", kwargs, str)
         )

--- a/packages/valory/skills/liquidity_trader_abci/pools/velodrome.py
+++ b/packages/valory/skills/liquidity_trader_abci/pools/velodrome.py
@@ -2953,7 +2953,7 @@ class VelodromePoolBehaviour(PoolBehaviour, ABC):
             f"Successfully created unstake transaction for {amount} LP tokens"
         )
         return {
-            # the gauge wrapper's withdraw already returns tx data as bytes
+            # raw tx calldata bytes, despite the tx_hash key name
             "tx_hash": withdraw_tx_hash,
             "contract_address": gauge_address,
             "amount": amount,

--- a/packages/valory/skills/liquidity_trader_abci/pools/velodrome.py
+++ b/packages/valory/skills/liquidity_trader_abci/pools/velodrome.py
@@ -2953,7 +2953,8 @@ class VelodromePoolBehaviour(PoolBehaviour, ABC):
             f"Successfully created unstake transaction for {amount} LP tokens"
         )
         return {
-            "tx_hash": bytes.fromhex(withdraw_tx_hash[2:]),
+            # the gauge wrapper's withdraw already returns tx data as bytes
+            "tx_hash": withdraw_tx_hash,
             "contract_address": gauge_address,
             "amount": amount,
             "success": True,

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -11,7 +11,7 @@ fingerprint:
   behaviours/base.py: bafybeian2n4ob4o7icuz3suraa7pszrvemi4fr5xscunybcai3lmkvxvfi
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeicgcoqk45xn67ymbf2bmjdrmiafn7hqcrqkxppa3t26bixlpsmupi
-  behaviours/decision_making.py: bafybeidar7ksuaqyg43m4epenqz5tvctic6syzxyo6bkynpaplqssmx6b4
+  behaviours/decision_making.py: bafybeibrgyketii4nbo7kal33esgitsk7ggjombelgwqplpedi6f6so47a
   behaviours/evaluate_strategy.py: bafybeicjsfpgzthad7dhrp3owklpgpwck3wcokzckukseuwle74w6gq7te
   behaviours/fetch_strategies.py: bafybeihbo4blzpdezityxhvdtwntzewalfro6uomjkigs4x66apnnteqgm
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
@@ -29,7 +29,7 @@ fingerprint:
   pools/__init__.py: bafybeigfi5svtn2csdf2nna6cfonjx7abkkwvfyt3sqmmtbcxvrv5vykpy
   pools/balancer.py: bafybeicmjq7itdf6hnsmbhxktb42ghzbdwmll56o66ex2ids6oiiql56ki
   pools/uniswap.py: bafybeihoegxrjsq6al3coxtrf5ljhewjz5m2py6nwwzefyoo7molc2fdsi
-  pools/velodrome.py: bafybeidn2vnkrfg6fuly3d2pf47bqoubeqzruhxecpor2o6k3f4fgszhvy
+  pools/velodrome.py: bafybeidqjtx4jwwuj7vcf3jgefams23okjutwoyrvnsbdvkz5fhkmhi32a
   rounds.py: bafybeighfkislaa362w6wbrcgjzv2dotuwhkqth2s4tt43z46kpw723nxi
   rounds_info.py: bafybeignjqqq6gu6ptr3xi3uyls3troxakfojbeue4hqx2biqwrjutmasu
   states/__init__.py: bafybeie5h3g3ndkq4c7tnv6c25tp64fn3jwyaatsm4buwyz2qiakpecgoy
@@ -49,7 +49,7 @@ fingerprint:
   tests/behaviours/test_base.py: bafybeieoaxfldhj35mj63y5is75auywkidh6sqip6ese7wdfop2ptb2jxm
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidcud7pqdkjmmimdrbn2ygndsf46aqs4rvfse5zinryes6lgxoz7u
-  tests/behaviours/test_decision_making.py: bafybeigwkixiwyo6nydbroqdwhopqhpujypdbqkx2ar5hkczlhbyiynnpq
+  tests/behaviours/test_decision_making.py: bafybeielsmcl4c57irjc4syvy7scteapljw32u6n5uo44jtiwozejakt2i
   tests/behaviours/test_evaluate_strategy.py: bafybeihfvpnx56ajddmmtrvm5pj2dgtrd54w3qhztgm2zdle5bnb2cpgf4
   tests/behaviours/test_fetch_strategies.py: bafybeihlgbn3qqxbgrcfczg3cjhfx4vcteap4fdkfsswetuszbtgijkoju
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -8,11 +8,11 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
-  behaviours/base.py: bafybeian2n4ob4o7icuz3suraa7pszrvemi4fr5xscunybcai3lmkvxvfi
+  behaviours/base.py: bafybeickpsut7xknpqn5yjxu6laufnbszzoog6ugleuvhdpwvvnvhigfgi
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeicgcoqk45xn67ymbf2bmjdrmiafn7hqcrqkxppa3t26bixlpsmupi
-  behaviours/decision_making.py: bafybeibrgyketii4nbo7kal33esgitsk7ggjombelgwqplpedi6f6so47a
-  behaviours/evaluate_strategy.py: bafybeicjsfpgzthad7dhrp3owklpgpwck3wcokzckukseuwle74w6gq7te
+  behaviours/decision_making.py: bafybeiegwhchjw3gzq6ej7v5bl3jtrpkvf6x5zbwribcbwp75iwzsc3js4
+  behaviours/evaluate_strategy.py: bafybeigyoh2qklj6vb2ocgkzc7nmpky274qud5pcfvyiaqahfnnl2ganqi
   behaviours/fetch_strategies.py: bafybeihbo4blzpdezityxhvdtwntzewalfro6uomjkigs4x66apnnteqgm
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
   behaviours/post_tx_settlement.py: bafybeia2fn7abt7zjifitv34vwylohqmuk5r7ptkdk62oeemg66v3klfii
@@ -46,10 +46,10 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeieoaxfldhj35mj63y5is75auywkidh6sqip6ese7wdfop2ptb2jxm
+  tests/behaviours/test_base.py: bafybeigoflwkecpexeemnub2cio6sryftqjp5zbv7y3t7jp4jucyt5z3pu
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidcud7pqdkjmmimdrbn2ygndsf46aqs4rvfse5zinryes6lgxoz7u
-  tests/behaviours/test_decision_making.py: bafybeielsmcl4c57irjc4syvy7scteapljw32u6n5uo44jtiwozejakt2i
+  tests/behaviours/test_decision_making.py: bafybeihksu3ty7xossbcalev7kqwsvb4v4wlixqii4gctbeigcglfnueyq
   tests/behaviours/test_evaluate_strategy.py: bafybeihfvpnx56ajddmmtrvm5pj2dgtrd54w3qhztgm2zdle5bnb2cpgf4
   tests/behaviours/test_fetch_strategies.py: bafybeihlgbn3qqxbgrcfczg3cjhfx4vcteap4fdkfsswetuszbtgijkoju
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -8,11 +8,11 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
-  behaviours/base.py: bafybeiejo5e2q54yt2tmsn3vsy6iidprsgneiztb7inyfuvcnotclcree4
+  behaviours/base.py: bafybeian2n4ob4o7icuz3suraa7pszrvemi4fr5xscunybcai3lmkvxvfi
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeicgcoqk45xn67ymbf2bmjdrmiafn7hqcrqkxppa3t26bixlpsmupi
   behaviours/decision_making.py: bafybeidar7ksuaqyg43m4epenqz5tvctic6syzxyo6bkynpaplqssmx6b4
-  behaviours/evaluate_strategy.py: bafybeihpzwvpqxjqr2gqbcpko6le3jx7xr3g4i7fxabiivpffewbqppone
+  behaviours/evaluate_strategy.py: bafybeicjsfpgzthad7dhrp3owklpgpwck3wcokzckukseuwle74w6gq7te
   behaviours/fetch_strategies.py: bafybeihbo4blzpdezityxhvdtwntzewalfro6uomjkigs4x66apnnteqgm
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
   behaviours/post_tx_settlement.py: bafybeia2fn7abt7zjifitv34vwylohqmuk5r7ptkdk62oeemg66v3klfii
@@ -46,11 +46,11 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeihefdotpk2cvzyrxq4xodtayyccjivj3ennsw4kn5x2futxhrvjae
+  tests/behaviours/test_base.py: bafybeieoaxfldhj35mj63y5is75auywkidh6sqip6ese7wdfop2ptb2jxm
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidcud7pqdkjmmimdrbn2ygndsf46aqs4rvfse5zinryes6lgxoz7u
-  tests/behaviours/test_decision_making.py: bafybeigbbk4ohzerw7655sgfqhpnp2z3lf2ddo3vo4mxz655b3up5rmwcy
-  tests/behaviours/test_evaluate_strategy.py: bafybeiegeypa7zafe4ex3kljxtcuxwei6iqltiihm7th7td6f65szll63i
+  tests/behaviours/test_decision_making.py: bafybeigwkixiwyo6nydbroqdwhopqhpujypdbqkx2ar5hkczlhbyiynnpq
+  tests/behaviours/test_evaluate_strategy.py: bafybeihfvpnx56ajddmmtrvm5pj2dgtrd54w3qhztgm2zdle5bnb2cpgf4
   tests/behaviours/test_fetch_strategies.py: bafybeihlgbn3qqxbgrcfczg3cjhfx4vcteap4fdkfsswetuszbtgijkoju
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu
   tests/behaviours/test_post_tx_settlement.py: bafybeigievecybq7geucnqou7av3rrqsnjitgxydbo6fjopmki34n74q5u

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -8,11 +8,11 @@ aea_version: '>=2.0.0, <3.0.0'
 fingerprint:
   __init__.py: bafybeihpcaip2rjmczq5arpguqyhjabfwnh4iuus4bet2wctedojd5h73m
   behaviours/__init__.py: bafybeiaomv5fjuaabfbz6a4zfplxyqgnqghl6ztdq3ald5retam44lo6ye
-  behaviours/base.py: bafybeigm5opkgzya2pdnlgbzl6izk3ubzrma3sdw43f3dowezqdfbydpme
+  behaviours/base.py: bafybeiejo5e2q54yt2tmsn3vsy6iidprsgneiztb7inyfuvcnotclcree4
   behaviours/call_checkpoint.py: bafybeibewplociomxxwyghkbnxj6llyg4vmtudcsdw3sgwemo6jlir2qge
   behaviours/check_staking_kpi_met.py: bafybeicgcoqk45xn67ymbf2bmjdrmiafn7hqcrqkxppa3t26bixlpsmupi
-  behaviours/decision_making.py: bafybeiecevpplgg23gptaexr6kp4opddeydms5lzziuehtngdxxc3mayw4
-  behaviours/evaluate_strategy.py: bafybeigvd26lxpdq27nfj2jvyexmvfpch7wqlo772rahvil6nvek26axp4
+  behaviours/decision_making.py: bafybeidar7ksuaqyg43m4epenqz5tvctic6syzxyo6bkynpaplqssmx6b4
+  behaviours/evaluate_strategy.py: bafybeihpzwvpqxjqr2gqbcpko6le3jx7xr3g4i7fxabiivpffewbqppone
   behaviours/fetch_strategies.py: bafybeihbo4blzpdezityxhvdtwntzewalfro6uomjkigs4x66apnnteqgm
   behaviours/get_positions.py: bafybeiahv2p2x2pprlmghzypyjp3axfsuuerwspg6jhlpep7sr2tzvje4i
   behaviours/post_tx_settlement.py: bafybeia2fn7abt7zjifitv34vwylohqmuk5r7ptkdk62oeemg66v3klfii
@@ -23,13 +23,13 @@ fingerprint:
   handlers.py: bafybeigxkxtlzq53eedt3ig27gmyarv7gd63p2dgzi3oqdnyuyjhiffzqi
   io_/__init__.py: bafybeiemrhqu7ii7n7c63x26jxiwer7a545eanfcqgasbqe7wb7b3ynvmi
   io_/loader.py: bafybeictieroff4sy6qgc6zm2vfnzhoeqwfz4k5cb4ccfsaajxzlnqkoae
-  models.py: bafybeihdkdetmh45xkfbug4brq7mwaz56y7agje6l5p4jq5slervlacjqu
+  models.py: bafybeiamqzx7oa64wajjt5znaojtq7xqwzarnslzfzrzxlmoiy75iqmp6m
   payloads.py: bafybeibvbjcwglyx3gasmx56u3nwneoxbkvefrry7pmguuayi3nlsa47oe
   pool_behaviour.py: bafybeidpz4kqbl5fpt2rtlmmdamnujbqu7rpdx726ntgsqsgeivwz3ylsu
   pools/__init__.py: bafybeigfi5svtn2csdf2nna6cfonjx7abkkwvfyt3sqmmtbcxvrv5vykpy
   pools/balancer.py: bafybeicmjq7itdf6hnsmbhxktb42ghzbdwmll56o66ex2ids6oiiql56ki
   pools/uniswap.py: bafybeihoegxrjsq6al3coxtrf5ljhewjz5m2py6nwwzefyoo7molc2fdsi
-  pools/velodrome.py: bafybeign5d7fvjew7oibe4xgck55qxaq2dwxvetmu6a55pqnwjc4wiozl4
+  pools/velodrome.py: bafybeidn2vnkrfg6fuly3d2pf47bqoubeqzruhxecpor2o6k3f4fgszhvy
   rounds.py: bafybeighfkislaa362w6wbrcgjzv2dotuwhkqth2s4tt43z46kpw723nxi
   rounds_info.py: bafybeignjqqq6gu6ptr3xi3uyls3troxakfojbeue4hqx2biqwrjutmasu
   states/__init__.py: bafybeie5h3g3ndkq4c7tnv6c25tp64fn3jwyaatsm4buwyz2qiakpecgoy
@@ -46,11 +46,11 @@ fingerprint:
   tests/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/behaviours/test___init__.py: bafybeihhuzqn5hzh55thnd373puykfszzd6kxsugu5e4ra63l72edh55lu
-  tests/behaviours/test_base.py: bafybeidmu5v6ljffq5akbzqopw6tvn7jtrtrseduwwpfwuqs3gs7c646jm
+  tests/behaviours/test_base.py: bafybeihefdotpk2cvzyrxq4xodtayyccjivj3ennsw4kn5x2futxhrvjae
   tests/behaviours/test_call_checkpoint.py: bafybeidfehszet7imqglv6rmlzd3gbvitxatvnts6voavv672vjv66w6m4
   tests/behaviours/test_check_staking_kpi_met.py: bafybeidcud7pqdkjmmimdrbn2ygndsf46aqs4rvfse5zinryes6lgxoz7u
-  tests/behaviours/test_decision_making.py: bafybeigs63ccyv6nivol2p4nqxvhfn6obkukib2kgaa5hzrhtje564ziuu
-  tests/behaviours/test_evaluate_strategy.py: bafybeies3glm2jbmt7v2ejwu2fgter2elqjq5k7e6nqclrkdplinzwsj4i
+  tests/behaviours/test_decision_making.py: bafybeigbbk4ohzerw7655sgfqhpnp2z3lf2ddo3vo4mxz655b3up5rmwcy
+  tests/behaviours/test_evaluate_strategy.py: bafybeiegeypa7zafe4ex3kljxtcuxwei6iqltiihm7th7td6f65szll63i
   tests/behaviours/test_fetch_strategies.py: bafybeihlgbn3qqxbgrcfczg3cjhfx4vcteap4fdkfsswetuszbtgijkoju
   tests/behaviours/test_get_positions.py: bafybeiazf6f4lx2ycjxa5zthsufvrnvaqjkvvzfnf5ywuleoctoji5hchu
   tests/behaviours/test_post_tx_settlement.py: bafybeigievecybq7geucnqou7av3rrqsnjitgxydbo6fjopmki34n74q5u
@@ -61,7 +61,7 @@ fingerprint:
   tests/pools/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/pools/test_balancer.py: bafybeidj3dmmzkjc32dznwdqnuvdsvlwa27jsoazvjvvikbu57bhlze3qq
   tests/pools/test_uniswap.py: bafybeib5rnfzaya4an2t4odvca23ee5id7ejwbsjrfjnuy22jytg76b5qi
-  tests/pools/test_velodrome.py: bafybeiew35cciuskja4oyqvdp5ddhg7prorzakdsa2nwxo3n2ecgza6hci
+  tests/pools/test_velodrome.py: bafybeibolzkmx4ucuam4cfza4zpmchitdt6sa2n63cph5mwjn4xl5fy2ja
   tests/states/__init__.py: bafybeid4v4exhnsqpccfjqrrhxcpg3w72vrwdp6o54edbyjjy7duti3ydm
   tests/states/test_base.py: bafybeigqdgbcey6ltlpffm6a44tnvkc66ivcth7u3dmezp4e3abd7o6fgq
   tests/states/test_call_checkpoint.py: bafybeihsjabiftgu4hikk3igo2roewspk6cscyy6cukaao254ntc6osmkm
@@ -76,7 +76,7 @@ fingerprint:
   tests/test___init__.py: bafybeicv7zly4wifncnlfzbdjebvdacb5ovogo677elvamntrb23ea3hl4
   tests/test_dialogues.py: bafybeigxvkwchtbxlelauxdqug2eayeiafxcyrxxpzfwzqztcytf3l4zk4
   tests/test_handlers.py: bafybeieytuiapfnjeu5t2xrz6n6rvijuml3buyxvm4snqluooymtvuuj5i
-  tests/test_models.py: bafybeidsz6m6uz5pxb57kgwzg62ypjjnsw7674icfcn4l4dnr2rehmo6qm
+  tests/test_models.py: bafybeigot3xdbx2eyplcmrjgugloouu36xe4oxjgqxla3t5rh77aveskpm
   tests/test_payloads.py: bafybeihgckap5l6g7gmj2g7bon4zp5oc23mo55pt32hstznwobfb24cifq
   tests/test_pool_behaviour.py: bafybeifjmzgidcgv33kph6dspm5stlunwxb3qbmczhppcxq52v4rorurlu
   tests/test_rounds.py: bafybeihkb4qxrwbmdnointbjelwttrw6styzs4rodmlbcnnaglvvqkczom
@@ -304,6 +304,7 @@ models:
       - optimism
       - mode
       staking_chain: optimism
+      fund_requirements: {}
       file_hash_to_strategies: '{"bafybeid7vmeeh6eeagyoa3nysq5oijyabous2eaw3gnm6yt5pnloimvbza":"merkl_pools_search","bafybeie4sceuc3z52jqtnsn5knnsjeogu6gsnetvp325ao2tf4vv3dqcee":"max_apr_selection"}'
       strategies_kwargs: '{"merkl_pools_search":[["balancer_graphql_endpoints",{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}],["merkl_fetch_campaign_args",{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}]]}'
       available_protocols:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -28,6 +28,8 @@ import time
 from typing import Any, Generator, Optional
 from unittest.mock import MagicMock, PropertyMock, patch
 
+import pytest
+
 from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
     AIRDROP_TOTAL_KEY,
     Action,
@@ -403,25 +405,19 @@ class TestMechFeeReserve:
         }
         return b
 
-    def test_reserve_from_safe_topup(self) -> None:
-        """The reserve equals the safe topup configured for the token."""
+    @pytest.mark.parametrize(
+        ("chain", "token", "expected"),
+        [
+            ("base", TOKEN, 4000),  # safe topup configured for the token
+            ("base", TOKEN.upper(), 4000),  # address matching ignores case
+            ("optimism", TOKEN, 0),  # chain without fund_requirements
+            ("base", ZERO_ADDRESS, 0),  # token without a safe entry
+        ],
+    )
+    def test_reserve_lookup(self, chain: str, token: str, expected: int) -> None:
+        """The reserve is the safe topup for the token, 0 when unconfigured."""
         b = self._behaviour_with_requirements(4000)
-        assert b._get_mech_fee_reserve("base", self.TOKEN) == 4000
-
-    def test_reserve_case_insensitive(self) -> None:
-        """Token address matching ignores case."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._get_mech_fee_reserve("base", self.TOKEN.upper()) == 4000
-
-    def test_reserve_unknown_chain(self) -> None:
-        """A chain without fund_requirements has no reserve."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._get_mech_fee_reserve("optimism", self.TOKEN) == 0
-
-    def test_reserve_token_not_configured(self) -> None:
-        """A token without a safe entry has no reserve."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._get_mech_fee_reserve("base", ZERO_ADDRESS) == 0
+        assert b._get_mech_fee_reserve(chain, token) == expected
 
     def test_reserve_ignores_agent_entries(self) -> None:
         """Agent-level requirements never count as a safe reserve."""
@@ -431,40 +427,38 @@ class TestMechFeeReserve:
         }
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
 
-    def test_reserve_invalid_topup_value(self) -> None:
-        """A non-numeric topup falls back to no reserve."""
-        b = self._behaviour_with_requirements("not-a-number")
+    @pytest.mark.parametrize("topup", ["not-a-number", None])
+    def test_reserve_malformed_topup_warns_and_disables(self, topup: Any) -> None:
+        """A malformed topup disables the reserve and logs a warning."""
+        b = self._behaviour_with_requirements(topup)
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
+        assert b.context.logger.warning.called
 
-    def test_reserve_none_topup_value(self) -> None:
-        """A None topup falls back to no reserve."""
-        b = self._behaviour_with_requirements(None)
+    def test_reserve_non_dict_safe_entry_warns_and_disables(self) -> None:
+        """A non-dict safe entry disables the reserve and logs a warning."""
+        b = _make_behaviour()
+        b.context.params.fund_requirements = {"base": {"safe": {self.TOKEN: 42}}}
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
+        assert b.context.logger.warning.called
 
-    def test_apply_deducts_reserve(self) -> None:
-        """The spendable balance is total minus the reserve."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._apply_mech_fee_reserve("base", self.TOKEN, 10000) == 6000
-
-    def test_apply_floors_at_zero(self) -> None:
-        """A balance below the reserve yields zero, never negative."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._apply_mech_fee_reserve("base", self.TOKEN, 3999) == 0
-
-    def test_apply_balance_equal_to_reserve(self) -> None:
-        """A balance equal to the reserve is fully reserved."""
-        b = self._behaviour_with_requirements(4000)
-        assert b._apply_mech_fee_reserve("base", self.TOKEN, 4000) == 0
+    @pytest.mark.parametrize(
+        ("topup", "balance", "expected"),
+        [
+            (4000, 10000, 6000),  # reserve deducted from balance
+            (4000, 3999, 0),  # balance below reserve floors at zero
+            (4000, 4000, 0),  # balance equal to reserve is fully reserved
+            (0, 10000, 10000),  # zero topup reserves nothing
+        ],
+    )
+    def test_apply_reserve(self, topup: int, balance: int, expected: int) -> None:
+        """The spendable balance is total minus the reserve, floored at zero."""
+        b = self._behaviour_with_requirements(topup)
+        assert b._apply_mech_fee_reserve("base", self.TOKEN, balance) == expected
 
     def test_apply_without_reserve_returns_balance(self) -> None:
         """Tokens without a configured reserve keep the full balance."""
         b = self._behaviour_with_requirements(4000)
         assert b._apply_mech_fee_reserve("base", ZERO_ADDRESS, 10000) == 10000
-
-    def test_apply_zero_reserve_returns_balance(self) -> None:
-        """A zero topup means nothing is reserved."""
-        b = self._behaviour_with_requirements(0)
-        assert b._apply_mech_fee_reserve("base", self.TOKEN, 10000) == 10000
 
 
 class TestGetActiveLpAddresses:

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -387,6 +387,86 @@ class TestGetBalance:
         assert b._get_balance("optimism", "0xabcd", positions) == 999
 
 
+class TestMechFeeReserve:
+    """Test _get_mech_fee_reserve and _apply_mech_fee_reserve."""
+
+    TOKEN = "0x" + "ab" * 20
+
+    def _behaviour_with_requirements(self, topup: Any) -> LiquidityTraderBaseBehaviour:
+        """Behaviour whose fund_requirements reserve ``topup`` for TOKEN on base."""
+        b = _make_behaviour()
+        b.context.params.fund_requirements = {
+            "base": {
+                "agent": {ZERO_ADDRESS: {"topup": 999, "threshold": 1}},
+                "safe": {self.TOKEN: {"topup": topup, "threshold": 350}},
+            }
+        }
+        return b
+
+    def test_reserve_from_safe_topup(self) -> None:
+        """The reserve equals the safe topup configured for the token."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._get_mech_fee_reserve("base", self.TOKEN) == 4000
+
+    def test_reserve_case_insensitive(self) -> None:
+        """Token address matching ignores case."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._get_mech_fee_reserve("base", self.TOKEN.upper()) == 4000
+
+    def test_reserve_unknown_chain(self) -> None:
+        """A chain without fund_requirements has no reserve."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._get_mech_fee_reserve("optimism", self.TOKEN) == 0
+
+    def test_reserve_token_not_configured(self) -> None:
+        """A token without a safe entry has no reserve."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._get_mech_fee_reserve("base", ZERO_ADDRESS) == 0
+
+    def test_reserve_ignores_agent_entries(self) -> None:
+        """Agent-level requirements never count as a safe reserve."""
+        b = _make_behaviour()
+        b.context.params.fund_requirements = {
+            "base": {"agent": {self.TOKEN: {"topup": 999, "threshold": 1}}}
+        }
+        assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
+
+    def test_reserve_invalid_topup_value(self) -> None:
+        """A non-numeric topup falls back to no reserve."""
+        b = self._behaviour_with_requirements("not-a-number")
+        assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
+
+    def test_reserve_none_topup_value(self) -> None:
+        """A None topup falls back to no reserve."""
+        b = self._behaviour_with_requirements(None)
+        assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
+
+    def test_apply_deducts_reserve(self) -> None:
+        """The spendable balance is total minus the reserve."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._apply_mech_fee_reserve("base", self.TOKEN, 10000) == 6000
+
+    def test_apply_floors_at_zero(self) -> None:
+        """A balance below the reserve yields zero, never negative."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._apply_mech_fee_reserve("base", self.TOKEN, 3999) == 0
+
+    def test_apply_balance_equal_to_reserve(self) -> None:
+        """A balance equal to the reserve is fully reserved."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._apply_mech_fee_reserve("base", self.TOKEN, 4000) == 0
+
+    def test_apply_without_reserve_returns_balance(self) -> None:
+        """Tokens without a configured reserve keep the full balance."""
+        b = self._behaviour_with_requirements(4000)
+        assert b._apply_mech_fee_reserve("base", ZERO_ADDRESS, 10000) == 10000
+
+    def test_apply_zero_reserve_returns_balance(self) -> None:
+        """A zero topup means nothing is reserved."""
+        b = self._behaviour_with_requirements(0)
+        assert b._apply_mech_fee_reserve("base", self.TOKEN, 10000) == 10000
+
+
 class TestGetActiveLpAddresses:
     """Test _get_active_lp_addresses."""
 

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_base.py
@@ -427,17 +427,27 @@ class TestMechFeeReserve:
         }
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
 
-    @pytest.mark.parametrize("topup", ["not-a-number", None])
+    @pytest.mark.parametrize("topup", ["not-a-number", None, -500, "-500"])
     def test_reserve_malformed_topup_warns_and_disables(self, topup: Any) -> None:
-        """A malformed topup disables the reserve and logs a warning."""
+        """A malformed or negative topup disables the reserve and logs a warning."""
         b = self._behaviour_with_requirements(topup)
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
         assert b.context.logger.warning.called
 
-    def test_reserve_non_dict_safe_entry_warns_and_disables(self) -> None:
-        """A non-dict safe entry disables the reserve and logs a warning."""
+    @pytest.mark.parametrize(
+        "fund_requirements",
+        [
+            {"base": {"safe": {TOKEN: 42}}},  # non-dict token entry
+            {"base": {"safe": "oops"}},  # non-dict safe container
+            {"base": "oops"},  # non-dict chain container
+        ],
+    )
+    def test_reserve_malformed_containers_warn_and_disable(
+        self, fund_requirements: Any
+    ) -> None:
+        """Any non-dict level of fund_requirements disables the reserve with a warning."""
         b = _make_behaviour()
-        b.context.params.fund_requirements = {"base": {"safe": {self.TOKEN: 42}}}
+        b.context.params.fund_requirements = fund_requirements
         assert b._get_mech_fee_reserve("base", self.TOKEN) == 0
         assert b.context.logger.warning.called
 

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -158,6 +158,11 @@ def _make_gen_none():
     return method
 
 
+def _fund_requirements(token: str, topup: int) -> dict:
+    """fund_requirements reserving ``topup`` of ``token`` in the optimism safe."""
+    return {"optimism": {"safe": {token: {"topup": topup, "threshold": 10}}}}
+
+
 def _make_gen_method_by_token(token_map):
     """Build a fake is_cl_token_staked that returns token_map[token_id]."""
 
@@ -2019,9 +2024,7 @@ class TestGetTokenBalancesAndCalculateAmounts:
         """The safe topup from fund_requirements is kept out of the amounts."""
         b = _make_behaviour()
         b._get_balance = MagicMock(return_value=1000)
-        b.params.fund_requirements = {
-            "optimism": {"safe": {"0x1": {"topup": 400, "threshold": 10}}}
-        }
+        b.params.fund_requirements = _fund_requirements("0x1", 400)
         result = _exhaust(
             b._get_token_balances_and_calculate_amounts("optimism", ["0x1", "0x2"], [])
         )
@@ -2902,9 +2905,7 @@ class TestCalculateVelodromeInvestmentAmounts:
         b._get_balance = MagicMock(return_value=1000)
         b._get_token_decimals = _make_gen_method(0)
         b._fetch_token_price = _make_gen_method(1.0)
-        b.params.fund_requirements = {
-            "optimism": {"safe": {"0x1": {"topup": 400, "threshold": 10}}}
-        }
+        b.params.fund_requirements = _fund_requirements("0x1", 400)
         action = {
             "token_requirements": {
                 "overall_token0_ratio": 0.5,
@@ -3944,6 +3945,19 @@ class TestGetDepositTxHash:
         result = _exhaust(b.get_deposit_tx_hash(action, []))
         assert result == (None, None, None)
 
+    def test_balance_none(self):
+        """An undeterminable balance aborts before any amount is computed."""
+        b = _make_behaviour()
+        b._get_balance = MagicMock(return_value=None)
+        action = {
+            "chain": "optimism",
+            "token0": self.TOKEN_ADDR,
+            "pool_address": self.POOL_ADDR,
+            "relative_funds_percentage": 1.0,
+        }
+        result = _exhaust(b.get_deposit_tx_hash(action, []))
+        assert result == (None, None, None)
+
     def test_success(self):
         """Test success."""
         b = _make_behaviour()
@@ -3965,9 +3979,7 @@ class TestGetDepositTxHash:
         """The deposited amount excludes the mech fee reserve."""
         b = _make_behaviour()
         b._get_balance = MagicMock(return_value=1000)
-        b.params.fund_requirements = {
-            "optimism": {"safe": {self.TOKEN_ADDR: {"topup": 400, "threshold": 10}}}
-        }
+        b.params.fund_requirements = _fund_requirements(self.TOKEN_ADDR, 400)
         captured = {}
 
         def approval(*a, **kw):
@@ -4609,7 +4621,8 @@ class TestFetchRoutes:
             {"chain": "optimism", "assets": [{"address": "0xT1", "balance": 10000}]}
         ]
 
-    def _routes_response(self):
+    @staticmethod
+    def _routes_response():
         resp = MagicMock()
         resp.status_code = 200
         resp.body = json.dumps({"routes": [{"steps": []}]})
@@ -4629,9 +4642,7 @@ class TestFetchRoutes:
         b._read_investing_paused = _make_gen_method(False)
         b._get_balance = MagicMock(return_value=10000)
         b._get_token_decimals = _make_gen_method(18)
-        b.params.fund_requirements = {
-            "optimism": {"safe": {"0xT1": {"topup": 4000, "threshold": 10}}}
-        }
+        b.params.fund_requirements = _fund_requirements("0xT1", 4000)
         b.get_http_response = _make_gen_method(self._routes_response())
         action = self._base_action()
         result = _exhaust(b.fetch_routes(self._positions(), action))
@@ -4644,9 +4655,7 @@ class TestFetchRoutes:
         b._read_investing_paused = _make_gen_method(True)
         b._get_balance = MagicMock(return_value=10000)
         b._get_token_decimals = _make_gen_method(18)
-        b.params.fund_requirements = {
-            "optimism": {"safe": {"0xT1": {"topup": 4000, "threshold": 10}}}
-        }
+        b.params.fund_requirements = _fund_requirements("0xT1", 4000)
         b.get_http_response = _make_gen_method(self._routes_response())
         action = self._base_action()
         result = _exhaust(b.fetch_routes(self._positions(), action))

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -2903,13 +2903,19 @@ class TestCalculateVelodromeInvestmentAmounts:
         )
         assert result is None
 
-    def test_mech_fee_reserve_deducted(self):
+    @pytest.mark.parametrize(
+        ("reserved_token", "expected"),
+        # Balances are 600/1000 (or 1000/600) after the 400 reserve:
+        # total USD 1600, 50/50 targets of 800 capped at the balances.
+        [("0x1", [600, 800]), ("0x2", [800, 600])],
+    )
+    def test_mech_fee_reserve_deducted(self, reserved_token, expected):
         """The mech fee reserve is excluded from the investable balances."""
         b = _make_behaviour()
         b._get_balance = MagicMock(return_value=1000)
         b._get_token_decimals = _make_gen_method(0)
         b._fetch_token_price = _make_gen_method(1.0)
-        b.params.fund_requirements = _fund_requirements("0x1", 400)
+        b.params.fund_requirements = _fund_requirements(reserved_token, 400)
         action = {
             "token_requirements": {
                 "overall_token0_ratio": 0.5,
@@ -2921,9 +2927,7 @@ class TestCalculateVelodromeInvestmentAmounts:
                 action, "optimism", ["0x1", "0x2"], [], []
             )
         )
-        # Balances are 600/1000 after the 400 reserve on token0:
-        # total USD 1600, 50/50 targets of 800 capped at the balances.
-        assert result == [600, 800]
+        assert result == expected
 
     def test_decimals_none(self):
         """Test decimals none."""
@@ -3962,16 +3966,23 @@ class TestGetDepositTxHash:
         result = _exhaust(b.get_deposit_tx_hash(action, []))
         assert result == (None, None, None)
 
-    def test_balance_fully_reserved(self):
-        """A balance at or below the mech fee reserve skips the deposit with a warning."""
+    @pytest.mark.parametrize(
+        ("balance", "topup", "percentage"),
+        [
+            (300, 400, 1.0),  # balance below the reserve
+            (1000, 999, 0.5),  # small remainder rounds the amount to zero
+        ],
+    )
+    def test_balance_consumed_by_reserve(self, balance, topup, percentage):
+        """A reserve-induced zero amount skips the deposit with a warning."""
         b = _make_behaviour()
-        b._get_balance = MagicMock(return_value=300)
-        b.params.fund_requirements = _fund_requirements(self.TOKEN_ADDR, 400)
+        b._get_balance = MagicMock(return_value=balance)
+        b.params.fund_requirements = _fund_requirements(self.TOKEN_ADDR, topup)
         action = {
             "chain": "optimism",
             "token0": self.TOKEN_ADDR,
             "pool_address": self.POOL_ADDR,
-            "relative_funds_percentage": 1.0,
+            "relative_funds_percentage": percentage,
         }
         result = _exhaust(b.get_deposit_tx_hash(action, []))
         assert result == (None, None, None)

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
+from packages.valory.contracts.gnosis_safe.contract import SafeOperation
 from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
     Action,
     Decision,
@@ -39,6 +40,9 @@ from packages.valory.skills.liquidity_trader_abci.behaviours.base import (
 )
 from packages.valory.skills.liquidity_trader_abci.behaviours.decision_making import (
     DecisionMakingBehaviour,
+)
+from packages.valory.skills.liquidity_trader_abci.pools.velodrome import (
+    VelodromePoolBehaviour,
 )
 from packages.valory.skills.liquidity_trader_abci.states.base import Event
 
@@ -2011,6 +2015,20 @@ class TestGetTokenBalancesAndCalculateAmounts:
         )
         assert result == (None, None, None)
 
+    def test_mech_fee_reserve_deducted(self):
+        """The safe topup from fund_requirements is kept out of the amounts."""
+        b = _make_behaviour()
+        b._get_balance = MagicMock(return_value=1000)
+        b.params.fund_requirements = {
+            "optimism": {"safe": {"0x1": {"topup": 400, "threshold": 10}}}
+        }
+        result = _exhaust(
+            b._get_token_balances_and_calculate_amounts("optimism", ["0x1", "0x2"], [])
+        )
+        assert result[0] == [600, 1000]
+        assert result[1] == 600
+        assert result[2] == 1000
+
 
 class TestGetTokenBalances:
     """TestGetTokenBalances."""
@@ -2877,6 +2895,30 @@ class TestCalculateVelodromeInvestmentAmounts:
             )
         )
         assert result is None
+
+    def test_mech_fee_reserve_deducted(self):
+        """The mech fee reserve is excluded from the investable balances."""
+        b = _make_behaviour()
+        b._get_balance = MagicMock(return_value=1000)
+        b._get_token_decimals = _make_gen_method(0)
+        b._fetch_token_price = _make_gen_method(1.0)
+        b.params.fund_requirements = {
+            "optimism": {"safe": {"0x1": {"topup": 400, "threshold": 10}}}
+        }
+        action = {
+            "token_requirements": {
+                "overall_token0_ratio": 0.5,
+                "overall_token1_ratio": 0.5,
+            }
+        }
+        result = _exhaust(
+            b._calculate_velodrome_investment_amounts(
+                action, "optimism", ["0x1", "0x2"], [], []
+            )
+        )
+        # Balances are 600/1000 after the 400 reserve on token0:
+        # total USD 1600, 50/50 targets of 800 capped at the balances.
+        assert result == [600, 800]
 
     def test_decimals_none(self):
         """Test decimals none."""
@@ -3919,6 +3961,33 @@ class TestGetDepositTxHash:
         result = _exhaust(b.get_deposit_tx_hash(action, []))
         assert result[0] is not None
 
+    def test_mech_fee_reserve_deducted(self):
+        """The deposited amount excludes the mech fee reserve."""
+        b = _make_behaviour()
+        b._get_balance = MagicMock(return_value=1000)
+        b.params.fund_requirements = {
+            "optimism": {"safe": {self.TOKEN_ADDR: {"topup": 400, "threshold": 10}}}
+        }
+        captured = {}
+
+        def approval(*a, **kw):
+            """Record the approval kwargs."""
+            captured.update(kw)
+            yield
+            return {"operation": 0, "to": self.POOL_ADDR, "value": 0, "data": b"x"}
+
+        b.get_approval_tx_hash = approval
+        b.contract_interact = _make_gen_method("0x" + "ab" * 32)
+        action = {
+            "chain": "optimism",
+            "token0": self.TOKEN_ADDR,
+            "pool_address": self.POOL_ADDR,
+            "relative_funds_percentage": 1.0,
+        }
+        result = _exhaust(b.get_deposit_tx_hash(action, []))
+        assert result[0] is not None
+        assert captured["amount"] == 600
+
     def test_approval_fails(self):
         """Test approval fails."""
         b = _make_behaviour()
@@ -4540,6 +4609,12 @@ class TestFetchRoutes:
             {"chain": "optimism", "assets": [{"address": "0xT1", "balance": 10000}]}
         ]
 
+    def _routes_response(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.body = json.dumps({"routes": [{"steps": []}]})
+        return resp
+
     def test_no_balance(self):
         """Test no balance."""
         b = _make_behaviour()
@@ -4547,6 +4622,36 @@ class TestFetchRoutes:
         b._get_balance = MagicMock(return_value=None)
         result = _exhaust(b.fetch_routes([], self._base_action()))
         assert result is None
+
+    def test_mech_fee_reserve_caps_swap_amount(self):
+        """The mech fee reserve is excluded from the amount sent to the router."""
+        b = _make_behaviour()
+        b._read_investing_paused = _make_gen_method(False)
+        b._get_balance = MagicMock(return_value=10000)
+        b._get_token_decimals = _make_gen_method(18)
+        b.params.fund_requirements = {
+            "optimism": {"safe": {"0xT1": {"topup": 4000, "threshold": 10}}}
+        }
+        b.get_http_response = _make_gen_method(self._routes_response())
+        action = self._base_action()
+        result = _exhaust(b.fetch_routes(self._positions(), action))
+        assert result is not None
+        assert action["amount"] == 6000
+
+    def test_mech_fee_reserve_bypassed_on_withdrawal(self):
+        """Withdrawals sweep the full balance, ignoring the reserve."""
+        b = _make_behaviour()
+        b._read_investing_paused = _make_gen_method(True)
+        b._get_balance = MagicMock(return_value=10000)
+        b._get_token_decimals = _make_gen_method(18)
+        b.params.fund_requirements = {
+            "optimism": {"safe": {"0xT1": {"topup": 4000, "threshold": 10}}}
+        }
+        b.get_http_response = _make_gen_method(self._routes_response())
+        action = self._base_action()
+        result = _exhaust(b.fetch_routes(self._positions(), action))
+        assert result is not None
+        assert action["amount"] == 10000
 
     def test_zero_amount(self):
         """Test zero amount."""
@@ -4966,6 +5071,41 @@ class TestStakeUnstakeClaimStakingRewards:
         action = self._velodrome_action()
         result = _exhaust(b.get_unstake_lp_tokens_tx_hash(action))
         assert result[0] is not None
+
+    def test_unstake_non_cl_real_pool_passes_gauge_tx_bytes_to_safe(self):
+        """Run the real Velodrome pool unstake path, stubbing only the contract boundary.
+
+        The gauge wrapper returns tx data as bytes and those bytes must
+        reach the Safe transaction call unchanged.
+        """
+        b = _make_behaviour()
+        b.params.velodrome_voter_contract_addresses = {"optimism": "0xVoter"}
+        b.pools = {"velodrome": VelodromePoolBehaviour}
+        withdraw_tx_data = bytes.fromhex("aabbccdd")
+        gauge_address = "0x" + "9a" * 20
+        responses = {
+            "gauges": gauge_address,
+            "balance_of": 500,
+            "withdraw": withdraw_tx_data,
+            "get_raw_safe_transaction_hash": "0x" + "ab" * 32,
+        }
+        safe_tx_calls = []
+
+        def contract_interact(*args: Any, **kwargs: Any) -> Any:
+            """Contract boundary stub keyed on the contract callable."""
+            yield
+            if kwargs["contract_callable"] == "get_raw_safe_transaction_hash":
+                safe_tx_calls.append(kwargs)
+            return responses[kwargs["contract_callable"]]
+
+        b.contract_interact = contract_interact
+        result = _exhaust(b.get_unstake_lp_tokens_tx_hash(self._velodrome_action()))
+        assert result[0] is not None
+        assert result[1] == "optimism"
+        assert len(safe_tx_calls) == 1
+        assert safe_tx_calls[0]["data"] == withdraw_tx_data
+        assert safe_tx_calls[0]["to_address"] == gauge_address
+        assert safe_tx_calls[0]["operation"] == SafeOperation.CALL.value
 
     def test_unstake_non_cl_no_staked(self):
         """Test unstake non cl no staked."""

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_decision_making.py
@@ -2020,17 +2020,21 @@ class TestGetTokenBalancesAndCalculateAmounts:
         )
         assert result == (None, None, None)
 
-    def test_mech_fee_reserve_deducted(self):
+    @pytest.mark.parametrize(
+        ("reserved_token", "expected"),
+        [("0x1", [600, 1000]), ("0x2", [1000, 600])],
+    )
+    def test_mech_fee_reserve_deducted(self, reserved_token, expected):
         """The safe topup from fund_requirements is kept out of the amounts."""
         b = _make_behaviour()
         b._get_balance = MagicMock(return_value=1000)
-        b.params.fund_requirements = _fund_requirements("0x1", 400)
+        b.params.fund_requirements = _fund_requirements(reserved_token, 400)
         result = _exhaust(
             b._get_token_balances_and_calculate_amounts("optimism", ["0x1", "0x2"], [])
         )
-        assert result[0] == [600, 1000]
-        assert result[1] == 600
-        assert result[2] == 1000
+        assert result[0] == expected
+        assert result[1] == expected[0]
+        assert result[2] == expected[1]
 
 
 class TestGetTokenBalances:
@@ -3957,6 +3961,21 @@ class TestGetDepositTxHash:
         }
         result = _exhaust(b.get_deposit_tx_hash(action, []))
         assert result == (None, None, None)
+
+    def test_balance_fully_reserved(self):
+        """A balance at or below the mech fee reserve skips the deposit with a warning."""
+        b = _make_behaviour()
+        b._get_balance = MagicMock(return_value=300)
+        b.params.fund_requirements = _fund_requirements(self.TOKEN_ADDR, 400)
+        action = {
+            "chain": "optimism",
+            "token0": self.TOKEN_ADDR,
+            "pool_address": self.POOL_ADDR,
+            "relative_funds_percentage": 1.0,
+        }
+        result = _exhaust(b.get_deposit_tx_hash(action, []))
+        assert result == (None, None, None)
+        assert b.context.logger.warning.called
 
     def test_success(self):
         """Test success."""

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_evaluate_strategy.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_evaluate_strategy.py
@@ -1032,6 +1032,36 @@ class TestCheckAndPrepareNonWhitelistedSwaps:
         result = self._call(b)
         assert result == []
 
+    def test_skips_native_eth(self):
+        """Native ETH in the safe is never swept to USDC."""
+        b = _mk()
+        b._get_usdc_address = MagicMock(return_value="0xusdc")
+        b._build_swap_to_usdc_action = MagicMock(
+            return_value={"action": "swap", "token": "ETH"}
+        )
+        synced_mock = MagicMock()
+        synced_mock.positions = [
+            {
+                "chain": "optimism",
+                "assets": [
+                    {
+                        "address": ZERO_ADDRESS,
+                        "asset_symbol": "ETH",
+                        "balance": 10**18,
+                    }
+                ],
+            }
+        ]
+        with patch.object(
+            type(b),
+            "synchronized_data",
+            new_callable=PropertyMock,
+            return_value=synced_mock,
+        ):
+            result = self._call(b)
+        assert result == []
+        b._build_swap_to_usdc_action.assert_not_called()
+
 
 class TestCalculateAggregateTokenRatios:
     """Tests for _calculate_aggregate_token_ratios."""
@@ -3260,6 +3290,26 @@ class TestGetInvestableBalance:
         b = _mk()
         result = _drive(b._get_investable_balance("optimism", "0x" + "ab" * 20, 1000))
         assert result == 1000
+
+    def test_mech_fee_reserve_deducted(self):
+        """The safe topup from fund_requirements is excluded from investment."""
+        b = _mk()
+        token = "0x" + "ab" * 20
+        b.params.fund_requirements = {
+            "optimism": {"safe": {token: {"topup": 300, "threshold": 10}}}
+        }
+        result = _drive(b._get_investable_balance("optimism", token, 1000))
+        assert result == 700
+
+    def test_mech_fee_reserve_exceeds_balance(self):
+        """A balance at or below the reserve is not investable at all."""
+        b = _mk()
+        token = "0x" + "ab" * 20
+        b.params.fund_requirements = {
+            "optimism": {"safe": {token: {"topup": 1000, "threshold": 10}}}
+        }
+        result = _drive(b._get_investable_balance("optimism", token, 1000))
+        assert result == 0
 
     def test_pure_reward_token(self):
         """Test pure reward token."""

--- a/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_evaluate_strategy.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/behaviours/test_evaluate_strategy.py
@@ -3291,25 +3291,22 @@ class TestGetInvestableBalance:
         result = _drive(b._get_investable_balance("optimism", "0x" + "ab" * 20, 1000))
         assert result == 1000
 
-    def test_mech_fee_reserve_deducted(self):
+    @pytest.mark.parametrize(
+        ("topup", "expected"),
+        [
+            (300, 700),  # reserve deducted from the balance
+            (1000, 0),  # reserve at or above the balance leaves nothing
+        ],
+    )
+    def test_mech_fee_reserve(self, topup, expected):
         """The safe topup from fund_requirements is excluded from investment."""
         b = _mk()
         token = "0x" + "ab" * 20
         b.params.fund_requirements = {
-            "optimism": {"safe": {token: {"topup": 300, "threshold": 10}}}
+            "optimism": {"safe": {token: {"topup": topup, "threshold": 10}}}
         }
         result = _drive(b._get_investable_balance("optimism", token, 1000))
-        assert result == 700
-
-    def test_mech_fee_reserve_exceeds_balance(self):
-        """A balance at or below the reserve is not investable at all."""
-        b = _mk()
-        token = "0x" + "ab" * 20
-        b.params.fund_requirements = {
-            "optimism": {"safe": {token: {"topup": 1000, "threshold": 10}}}
-        }
-        result = _drive(b._get_investable_balance("optimism", token, 1000))
-        assert result == 0
+        assert result == expected
 
     def test_pure_reward_token(self):
         """Test pure reward token."""

--- a/packages/valory/skills/liquidity_trader_abci/tests/pools/test_velodrome.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/pools/test_velodrome.py
@@ -4741,17 +4741,23 @@ class TestUnstakeLpTokens:
         assert "withdraw" in result["error"].lower()
 
     def test_success(self) -> None:
-        """Happy path."""
+        """Happy path.
+
+        The gauge wrapper's withdraw returns tx data as bytes and the
+        result must carry those bytes through unchanged.
+        """
         b = make_behaviour()
         b.params.velodrome_voter_contract_addresses = {"optimism": "0xVoter"}
-        b.contract_interact = make_contract_interact(["0xGauge", 200, "0xaabbccdd"])
+        withdraw_tx_data = bytes.fromhex("aabbccdd")
+        b.contract_interact = make_contract_interact(["0xGauge", 200, withdraw_tx_data])
         result = exhaust_generator(
             b.unstake_lp_tokens("0xLP", 100, chain="optimism", safe_address="0xSafe")
         )
         assert result["success"] is True
         assert result["is_multisend"] is False
         assert result["amount"] == 100
-        assert isinstance(result["tx_hash"], bytes)
+        assert result["contract_address"] == "0xGauge"
+        assert result["tx_hash"] == withdraw_tx_data
 
 
 class TestClaimRewards:

--- a/packages/valory/skills/liquidity_trader_abci/tests/test_models.py
+++ b/packages/valory/skills/liquidity_trader_abci/tests/test_models.py
@@ -595,6 +595,7 @@ class TestParams:
             "balancer_graphql_endpoints": json.dumps({}),
             "target_investment_chains": ["ethereum"],
             "staking_chain": "ethereum",
+            "fund_requirements": {},
             "file_hash_to_strategies": json.dumps({}),
             "strategies_kwargs": json.dumps({}),
             "available_protocols": ["balancerPool"],

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
+- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeibxkaukxrdjvkqmen5i4v67ouvyfve6v7gcxabscvozgx7ffxndde
+- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeigoe5msyzv2ompaxvhyijqf54666nltucnblqzuezysfesnzsjip4
+- valory/liquidity_trader_abci:0.1.0:bafybeiggg2skakianedd7c6i53n4svap7zxwea7qoo5wtcurio2ycyhyey
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy
@@ -371,6 +371,7 @@ models:
       - optimism
       - mode
       staking_chain: optimism
+      fund_requirements: {}
       file_hash_to_strategies: '{"bafybeid7vmeeh6eeagyoa3nysq5oijyabous2eaw3gnm6yt5pnloimvbza":"merkl_pools_search","bafybeie4sceuc3z52jqtnsn5knnsjeogu6gsnetvp325ao2tf4vv3dqcee":"max_apr_selection"}'
       strategies_kwargs: '{"merkl_pools_search":[["balancer_graphql_endpoints",{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}],["merkl_fetch_campaign_args",{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}]]}'
       available_protocols:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -175,7 +175,7 @@ skills:
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
-- valory/liquidity_trader_abci:0.1.0:bafybeiboc2qvgto5t6cr3snwo4qmxxce5l24wzcqbqmplk5foy7gtsyipa
+- valory/liquidity_trader_abci:0.1.0:bafybeidriubtvnzbstj2ydczozj3xehc6e5dknp6dlma5urri43vrnqpnq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/funds_manager:0.1.0:bafybeibne4vkmbper3ryn7q6kt7lclbyylgorziscyn6msr5qt46aihv4m
 - valory/mech_interact_abci:0.1.0:bafybeidnmszufszq3ro4ebgrqzmhqgctrsc6sykeanfsbvotghvt2cgfsy


### PR DESCRIPTION
## Context

Basius (Optimus on Base) Pearl agents were not earning staking rewards. The chain of causes:

1. Mech requests on Base go through the marketplace mech (mech 112), which charges 100 wei of native ETH per request, paid from the agent safe.
2. `fund_requirements` had the base safe's native entry at `topup: 0, threshold: 0`, so the Pearl middleware never auto-funded the safe with native ETH.
3. The trader treats the entire safe balance as investable. Any native ETH that did land on the safe was either invested into pools or swept to USDC by the non-whitelisted-asset cleanup, so there was never anything left to pay mech fees with. No mech requests means the staking KPI is missed and no rewards accrue.

Separately, users trying to withdraw from Velodrome v2 staked positions were stuck: withdrawals looped forever in the FSM (one user withdrawal pending since 2026-07-01).

## Changes

**1. Funding config (basius + optimus service/agent yamls)**
- Base safe native ETH requirement is now `topup: 100000000000000` (0.0001 ETH), `threshold: 350` wei, so the middleware funds the safe and tops it up when it runs low. At 100 wei per request the topup covers mech fees for far longer than the refill cadence.
- The USDC requirement on the base safe is removed (mech fees on Base are paid in native ETH, not USDC).
- The same `fund_requirements` dict is now also passed to `liquidity_trader_abci` (new skill param), for both basius and optimus, so the trader knows what the funding floor is.

**2. Mech fee reserve in the trader (`liquidity_trader_abci`)**
- New helpers `_get_mech_fee_reserve` / `_apply_mech_fee_reserve` in `behaviours/base.py`: the safe `topup` for a token in `fund_requirements` is treated as a reserve and deducted from the balance the trader considers investable (`max(0, balance - reserve)`).
- Applied at the selection layer (`_get_investable_balance` in `evaluate_strategy.py`) and at every execution-layer amount derivation in `decision_making.py`: velodrome investment amounts, token-balance based amounts, deposits, and swap route amounts.
- Withdrawals bypass the reserve: when `investing_paused` is set (the withdrawal flow), route amounts are not reduced, so users can always withdraw their full funds.

**3. Native ETH excluded from the swap-to-USDC cleanup**
- `check_and_prepare_non_whitelisted_swaps` now skips the zero address. Previously it would swap the safe's native ETH (the mech fee gas) into USDC and invest it.

**4. Velodrome v2 gauge unstake crash fix**
- Since 72cda47e the velodrome contract wrappers return tx data as `bytes` (`velodrome_gauge/contract.py` `withdraw` returns `bytes.fromhex(data[2:])`), but `unstake_lp_tokens` in `pools/velodrome.py` still re-applied `bytes.fromhex` on the result. Every non-CL gauge unstake raised `TypeError`, which was swallowed by the `except` in `get_unstake_lp_tokens_tx_hash`, returning no transaction and leaving the FSM looping on the withdrawal forever.
- Fix is a one-line pass-through of the wrapper's bytes. A sweep of all other `bytes.fromhex` call sites in the skill confirmed they consume MultiSend `get_tx_data` outputs or event-log fields, which are still hex strings, so they are correct and untouched.
- Once deployed, stuck withdrawals resume automatically from the exit-pools step, no manual intervention needed.

## Tests

- Unit tests for the reserve helpers (case-insensitive address match, unknown chain/token, invalid values, floor at zero).
- One test per execution-layer reserve site asserting the exact deducted amounts, plus the on/off pair for the withdrawal bypass.
- Native ETH skip test for the cleanup path.
- Unstake fix: the happy-path unit test now stubs the withdraw call with bytes, matching what the real wrapper returns (this test fails on the old code with the production `TypeError`), plus an integration-style test that runs the real `VelodromePoolBehaviour` through `get_unstake_lp_tokens_tx_hash` with only the contract boundary stubbed, asserting the gauge tx bytes reach the Safe call unchanged (also fails on the old code).

## Test plan

- [x] Full `liquidity_trader_abci` test suite passes locally
- [x] All CI checks run locally: black/isort/flake8/darglint, mypy/pylint, check-hash, check-packages, check-abci-docstrings, check-abciapp-specs, check-handlers, check-dependencies, liccheck, check-third-party-hashes, check-doc-hashes, gitleaks
- [x] `autonomy packages lock` + `lock --check`, `autonomy push-all` done
- [ ] Deploy new basius service hash via Pearl and confirm mech requests are funded and the stuck withdrawal completes

## On-chain payment-type evidence

- Base mech 112 (`0xe535D7AcDEeD905dddcb5443f41980436833cA2B`): `paymentType()` = `0xba699a34be8fe0e7725e93dcbce1701b0211a8ca61330aaeb8a05bf2ec7abed1` (`PaymentType.NATIVE`), `maxDeliveryRate()` = 100 wei. This is why the Base USDC safe entry is removed and a native reserve is added instead.
- Optimism mech 195 (`0x3208Dc0DebA018dDE8a8e2FFA09265Ea12aAf55E`): `paymentType()` = `0x6406bb5f31a732f898e1ce9fdd988a80a808d36ab5d9a4a4805a8be8d197d5e3` (`PaymentType.TOKEN_USDC`), `maxDeliveryRate()` = 10000 (0.01 USDC). This is why the Optimism reserve is on USDC (0.7 USDC covers ~70 requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

