### PR TITLE
fix(optimus_abci): add fund_requirements default to composed skill.yaml

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,11 +24,11 @@
         "contract/valory/balancer_queries/0.1.0": "bafybeihbexpjj6ho3ij7rxk4tzz3sowpa5ztawlf63y5fdmmom7xifpan4",
         "contract/valory/mech_activity/0.1.0": "bafybeienezl3yozrionpoyh75r54e24tjtnstxv674ru25lnosps3a7cr4",
         "skill/valory/liquidity_trader_abci/0.1.0": "bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64",
-        "skill/valory/optimus_abci/0.1.0": "bafybeihclddpjmfu6waw4ph4xz2pwxjtj4uerbbdd2442ugtotwgggfyh4",
-        "agent/valory/optimus/0.1.0": "bafybeihidpdpzchbxqnndnjgk4uqmhgzcjwgqsaafceux2a2hyraogjshq",
-        "agent/valory/basius/0.1.0": "bafybeifubm255az2d37huxdg5pt5xmjv3oq5h2ms3zqwxu2eze2htjv6dy",
-        "service/valory/optimus/0.1.0": "bafybeicyvlb7ftfcfyhhevjhfaeeubagve45xhbymx3qyill3bdykofszu",
-        "service/valory/basius/0.1.0": "bafybeihtx4xbpj22kmarp2pivanccocfeqjuedlaac44zcwaidx3cm6664"
+        "skill/valory/optimus_abci/0.1.0": "bafybeieryroxqsfuhldhip6pj437u7unws5pme6vzr4tu7j25mjfeo3uku",
+        "agent/valory/optimus/0.1.0": "bafybeidjkrxvs372256ivzo4m2eku4ikkli72sk6ubq42harc2gatudwz4",
+        "agent/valory/basius/0.1.0": "bafybeiauoyu5tseli42fk6n5sa7fi5umo2ick5xjmm7myr7x27uyoe4k3e",
+        "service/valory/optimus/0.1.0": "bafybeieauvbqf4mlsxfnt5yzs4hmhae43nkca2rsnklnyundzpqj42jyt4",
+        "service/valory/basius/0.1.0": "bafybeigoetjxteip6ic7fryr3sikbl4f7iuannkqegf5fgurlgiibf574e"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -73,7 +73,7 @@ skills:
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 - valory/liquidity_trader_abci:0.1.0:bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64
 - valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
-- valory/optimus_abci:0.1.0:bafybeihclddpjmfu6waw4ph4xz2pwxjtj4uerbbdd2442ugtotwgggfyh4
+- valory/optimus_abci:0.1.0:bafybeieryroxqsfuhldhip6pj437u7unws5pme6vzr4tu7j25mjfeo3uku
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -73,7 +73,7 @@ skills:
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 - valory/liquidity_trader_abci:0.1.0:bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64
 - valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
-- valory/optimus_abci:0.1.0:bafybeihclddpjmfu6waw4ph4xz2pwxjtj4uerbbdd2442ugtotwgggfyh4
+- valory/optimus_abci:0.1.0:bafybeieryroxqsfuhldhip6pj437u7unws5pme6vzr4tu7j25mjfeo3uku
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeifubm255az2d37huxdg5pt5xmjv3oq5h2ms3zqwxu2eze2htjv6dy
+agent: valory/basius:0.1.0:bafybeiauoyu5tseli42fk6n5sa7fi5umo2ick5xjmm7myr7x27uyoe4k3e
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeihidpdpzchbxqnndnjgk4uqmhgzcjwgqsaafceux2a2hyraogjshq
+agent: valory/optimus:0.1.0:bafybeidjkrxvs372256ivzo4m2eku4ikkli72sk6ubq42harc2gatudwz4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -379,6 +379,7 @@ models:
       - optimism
       - mode
       staking_chain: optimism
+      fund_requirements: {}
       file_hash_to_strategies: '{"bafybeid7vmeeh6eeagyoa3nysq5oijyabous2eaw3gnm6yt5pnloimvbza":"merkl_pools_search","bafybeie4sceuc3z52jqtnsn5knnsjeogu6gsnetvp325ao2tf4vv3dqcee":"max_apr_selection"}'
       strategies_kwargs: '{"merkl_pools_search":[["balancer_graphql_endpoints",{"optimism":"https://api.studio.thegraph.com/query/75376/balancer-optimism-v2/version/latest","base":"https://api.studio.thegraph.com/query/24660/balancer-base-v2/version/latest","mode":"https://api.studio.thegraph.com/query/75376/balancer-mode-v2/version/latest"}],["merkl_fetch_campaign_args",{"url":"https://api.merkl.xyz/v3/campaigns","creator":"","live":"false"}]]}'
       available_protocols:


### PR DESCRIPTION
## Summary

Unblocks the standalone agent-runner build that failed on the [v0.12.4 Release Flow](https://github.com/valory-xyz/optimus/actions/runs/28879174065/job/85662585883):

\`\`\`
aea.exceptions.AEAEnforceError: 'fund_requirements' of type 'typing.Dict[str, typing.Any]' required,
but it is not set in models.params.args of skill.yaml of valory/optimus_abci:0.1.0
\`\`\`

## Root cause

\`liquidity_trader_abci/models.py:528\` declares \`fund_requirements\` as a required param via \`self._ensure("fund_requirements", kwargs, Dict[str, Any])\`. \`optimus_abci\` composes that base skill and its \`skill.yaml\` sets the sibling required params under \`models.params.args\` (\`target_investment_chains\`, \`staking_chain\`, \`file_hash_to_strategies\`, \`strategies_kwargs\`, \`max_slippage_percentage\`, etc.) but was **missing \`fund_requirements\`**.

\`aea-config.yaml\` and \`service.yaml\` for both \`basius\` and \`optimus\` agents already override \`fund_requirements\` at deploy time (chain-scoped topups + thresholds), so live deployments work. The \`check-agent-runner\` smoke test in the Release Flow runs the built PyInstaller binary without those agent-level overrides applied — that's the path where the skill-level default matters, and where \`AEAEnforceError\` fires.

## Fix

- \`packages/valory/skills/optimus_abci/skill.yaml\`: adds \`fund_requirements: {}\` between \`staking_chain\` and \`file_hash_to_strategies\`, matching the order of the corresponding \`_ensure\` calls in \`liquidity_trader_abci/models.py\`.
- \`autonomy packages lock\` cascades the skill hash into both agent (\`basius\`, \`optimus\`) and service (\`basius\`, \`optimus\`) hashes.

The empty dict is a safe default: aea-config overrides on both agents still land the real chain-scoped fund_requirements at boot; the check-agent-runner smoke test now boots the composed skill without complaint.

## Release status recap

v0.12.4 shipped docker images, package hashes, and multi-arch manifests successfully. Only the standalone agent-runner binaries (and therefore \`upload-assets\`) failed. Once this lands on \`main\`, cutting v0.12.5 should produce a green release across all matrix entries.

## Test plan

- [ ] CI green (lock_check, copyright_and_dependencies_check, linter_checks, tests)
- [ ] \`build-agent-runner\` job on the release cut from this branch (v0.12.5) green across all matrix entries
- [ ] Basius / Optimus agent boots on staging deployment with the aea-config \`fund_requirements\` override honoured (no regression)