### PR TITLE
chore: bump mech-interact to v0.32.5

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,12 +23,12 @@
         "contract/valory/velodrome_cl_gauge/0.1.0": "bafybeihyci7aqcrefyy4uak245jq2ud2536c7lqjgmxuzwilfwtw7p2a4y",
         "contract/valory/balancer_queries/0.1.0": "bafybeihbexpjj6ho3ij7rxk4tzz3sowpa5ztawlf63y5fdmmom7xifpan4",
         "contract/valory/mech_activity/0.1.0": "bafybeienezl3yozrionpoyh75r54e24tjtnstxv674ru25lnosps3a7cr4",
-        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64",
-        "skill/valory/optimus_abci/0.1.0": "bafybeihjwwpqycxqxa7c46bi4dyvliiut4dm5za5aewkihpdtky65vo3qy",
-        "agent/valory/optimus/0.1.0": "bafybeieadiojxy2nkk5tm67u7lnmo7jfsmjmn3qelhidwcaanwy4ajfy2e",
-        "agent/valory/basius/0.1.0": "bafybeicxuzqqtb62bx5riqihue6sihblujltkyujxpvxidtuvfrggc7tru",
-        "service/valory/optimus/0.1.0": "bafybeigxjo3luwej3eissqwlowe6vez3toa72wq63rqxjfbjkljygs5ov4",
-        "service/valory/basius/0.1.0": "bafybeif4vwaxgn7mjxsbb2gimr7dqws6glnptexfwvq53pexox37wi4rvu"
+        "skill/valory/liquidity_trader_abci/0.1.0": "bafybeihro5okdx6rlyaqcpqfnsbswomyjtmoi3asf6q6vicynt2zm3ka4i",
+        "skill/valory/optimus_abci/0.1.0": "bafybeiakfcgar4t7rkfxs2ams4mvg7xti4sirzm2lufngemy2rjmgzkdw4",
+        "agent/valory/optimus/0.1.0": "bafybeihbfrttvgmniwiallnmvgockqenojtcvmtzf5h7qzwvudca56pm5u",
+        "agent/valory/basius/0.1.0": "bafybeif4t7pybfoy66sm4y4ai4eczgxagc43ooe4i4pw2bwoq2xp4y6xgq",
+        "service/valory/optimus/0.1.0": "bafybeie5tlaylmtx7malx2pe56dir54xu75nwsvcd56nuwgffo5phspgr4",
+        "service/valory/basius/0.1.0": "bafybeiaxmgxmxwxjdq5vi263cyxq2mibwo6keof3b5mmfjoej76tmuv2ni"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -83,6 +83,6 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje"
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha"
     }
 }

--- a/packages/valory/agents/basius/aea-config.yaml
+++ b/packages/valory/agents/basius/aea-config.yaml
@@ -71,9 +71,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
-- valory/liquidity_trader_abci:0.1.0:bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
-- valory/optimus_abci:0.1.0:bafybeihjwwpqycxqxa7c46bi4dyvliiut4dm5za5aewkihpdtky65vo3qy
+- valory/liquidity_trader_abci:0.1.0:bafybeihro5okdx6rlyaqcpqfnsbswomyjtmoi3asf6q6vicynt2zm3ka4i
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
+- valory/optimus_abci:0.1.0:bafybeiakfcgar4t7rkfxs2ams4mvg7xti4sirzm2lufngemy2rjmgzkdw4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi

--- a/packages/valory/agents/optimus/aea-config.yaml
+++ b/packages/valory/agents/optimus/aea-config.yaml
@@ -71,9 +71,9 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
-- valory/liquidity_trader_abci:0.1.0:bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
-- valory/optimus_abci:0.1.0:bafybeihjwwpqycxqxa7c46bi4dyvliiut4dm5za5aewkihpdtky65vo3qy
+- valory/liquidity_trader_abci:0.1.0:bafybeihro5okdx6rlyaqcpqfnsbswomyjtmoi3asf6q6vicynt2zm3ka4i
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
+- valory/optimus_abci:0.1.0:bafybeiakfcgar4t7rkfxs2ams4mvg7xti4sirzm2lufngemy2rjmgzkdw4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi

--- a/packages/valory/services/basius/service.yaml
+++ b/packages/valory/services/basius/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/basius:0.1.0:bafybeicxuzqqtb62bx5riqihue6sihblujltkyujxpvxidtuvfrggc7tru
+agent: valory/basius:0.1.0:bafybeif4t7pybfoy66sm4y4ai4eczgxagc43ooe4i4pw2bwoq2xp4y6xgq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/optimus/service.yaml
+++ b/packages/valory/services/optimus/service.yaml
@@ -6,7 +6,7 @@ aea_version: '>=2.0.0, <3.0.0'
 license: Apache-2.0
 fingerprint: {}
 fingerprint_ignore_patterns: []
-agent: valory/optimus:0.1.0:bafybeieadiojxy2nkk5tm67u7lnmo7jfsmjmn3qelhidwcaanwy4ajfy2e
+agent: valory/optimus:0.1.0:bafybeihbfrttvgmniwiallnmvgockqenojtcvmtzf5h7qzwvudca56pm5u
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/skills/liquidity_trader_abci/skill.yaml
+++ b/packages/valory/skills/liquidity_trader_abci/skill.yaml
@@ -123,7 +123,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 behaviours:
   main:

--- a/packages/valory/skills/optimus_abci/skill.yaml
+++ b/packages/valory/skills/optimus_abci/skill.yaml
@@ -176,10 +176,10 @@ skills:
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/liquidity_trader_abci:0.1.0:bafybeianso2jgr74rfyxfvwugkzlmmdqmwqyaxgpoquyjozjbwrvlhdz64
+- valory/liquidity_trader_abci:0.1.0:bafybeihro5okdx6rlyaqcpqfnsbswomyjtmoi3asf6q6vicynt2zm3ka4i
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ service_specific_packages_exclude = [
     "packages/valory/contracts/uniswap_v3_pool",
 ]
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.4",
+    "valory-xyz/mech-interact@v0.32.5",
     "valory-xyz/mech@v0.34.2-rc2",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",


### PR DESCRIPTION
## Summary

Bumps \`skill/valory/mech_interact_abci/0.1.0\` to \`bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha\` (mech-interact [v0.32.5](https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.5)).

The v0.32.5 release lands the off-chain request/response epic ([mech-interact#103](https://github.com/valory-xyz/mech-interact/pull/103)) plus the follow-up review fixes. Downstream skill / agent / service fingerprints refreshed via \`autonomy packages lock\` and new content published via \`autonomy push-all\`.

## Test plan

- [x] \`autonomy packages sync\` clean against the new hash set
- [x] \`autonomy packages lock\` refreshed downstream hashes
- [x] \`autonomy push-all\` published the new skill / agent / service content to IPFS
- [ ] Full CI green on this rollup